### PR TITLE
Use functools.wraps insterad of __wraped__ and manual proxing __name__

### DIFF
--- a/superqt/utils/_ensure_thread.py
+++ b/superqt/utils/_ensure_thread.py
@@ -1,5 +1,6 @@
 # https://gist.github.com/FlorianRhiem/41a1ad9b694c14fb9ac3
 from concurrent.futures import Future
+from functools import wraps
 from typing import Callable, List, Optional
 
 from superqt.qtcompat.QtCore import (
@@ -50,20 +51,17 @@ def ensure_main_thread(
         before raising a TimeoutError, by default 1000
     """
 
-    def _out_func(func):
+    def _out_func(func_):
+        @wraps(func_)
         def _func(*args, **kwargs):
             return _run_in_thread(
-                func,
+                func_,
                 QCoreApplication.instance().thread(),
                 await_return,
                 timeout,
                 *args,
                 **kwargs,
             )
-
-        if hasattr(func, "__name__"):
-            _func.__name__ = func.__name__
-        _func.__wrapped__ = func
 
         return _func
 
@@ -91,15 +89,12 @@ def ensure_object_thread(
         before raising a TimeoutError, by default 1000
     """
 
-    def _out_func(func):
+    def _out_func(func_):
+        @wraps(func_)
         def _func(self, *args, **kwargs):
             return _run_in_thread(
-                func, self.thread(), await_return, timeout, self, *args, **kwargs
+                func_, self.thread(), await_return, timeout, self, *args, **kwargs
             )
-
-        if hasattr(func, "__name__"):
-            _func.__name__ = func.__name__
-        _func.__wrapped__ = func
 
         return _func
 

--- a/superqt/utils/_tests/test_ensure_thread.py
+++ b/superqt/utils/_tests/test_ensure_thread.py
@@ -1,3 +1,4 @@
+import inspect
 import time
 from concurrent.futures import Future, TimeoutError
 
@@ -72,7 +73,8 @@ class SampleObject(QObject):
         return a * 7
 
     @ensure_object_thread(await_return=False)
-    def check_object_thread_return_future(self, a):
+    def check_object_thread_return_future(self, a: int):
+        """sample docstring"""
         if QThread.currentThread() is not self.thread():
             raise RuntimeError("Wrong thread")
         time.sleep(0.4)
@@ -186,7 +188,7 @@ def test_main_thread_return(qtbot):
     assert t.executed
 
 
-def test_names(qtbot):
+def test_names(qapp):
     ob = SampleObject()
     assert ob.check_object_thread.__name__ == "check_object_thread"
     assert ob.check_object_thread_return.__name__ == "check_object_thread_return"
@@ -198,4 +200,9 @@ def test_names(qtbot):
         ob.check_object_thread_return_future.__name__
         == "check_object_thread_return_future"
     )
+    assert ob.check_object_thread_return_future.__doc__ == "sample docstring"
+    signature = inspect.signature(ob.check_object_thread_return_future)
+    assert len(signature.parameters) == 1
+    assert list(signature.parameters.values())[0].name == "a"
+    assert list(signature.parameters.values())[0].annotation == int
     assert ob.check_main_thread_return.__name__ == "check_main_thread_return"


### PR DESCRIPTION
Using functools.wraps help to not lost  `__module__`, `__name__`, `__qualname__`, `__annotations__` and `__doc__`.

https://docs.python.org/3/library/functools.html#functools.wraps