### PR TITLE
feat: Change icon used in Collapsible widget

### DIFF
--- a/examples/qcollapsible.py
+++ b/examples/qcollapsible.py
@@ -6,6 +6,8 @@ from superqt import QCollapsible
 app = QApplication([])
 
 collapsible = QCollapsible("Advanced analysis")
+collapsible.setCollapsedIcon("+")
+collapsible.setExpandedIcon("-")
 collapsible.addWidget(QLabel("This is the inside of the collapsible frame"))
 for i in range(10):
     collapsible.addWidget(QPushButton(f"Content button {i + 1}"))

--- a/src/superqt/collapsible/_collapsible.py
+++ b/src/superqt/collapsible/_collapsible.py
@@ -38,7 +38,6 @@ class QCollapsible(QFrame):
         self._toggle_btn.setCheckable(True)
         self.set_collapsed_icon()
         self.set_expanded_icon()
-        self._toggle_btn.setIcon(self._COLLAPSED)
         self._toggle_btn.setStyleSheet("text-align: left; border: none; outline: none;")
         self._toggle_btn.toggled.connect(self._toggle)
 
@@ -120,6 +119,8 @@ class QCollapsible(QFrame):
 
             del painter
             del pixmap
+
+        self._toggle_btn.setIcon(self._COLLAPSED)
 
     def setDuration(self, msecs: int):
         """Set duration of the collapse/expand animation."""

--- a/src/superqt/collapsible/_collapsible.py
+++ b/src/superqt/collapsible/_collapsible.py
@@ -83,7 +83,8 @@ class QCollapsible(QFrame):
         """Return the current content widget."""
         return self._content
 
-    def _convert_symbol_to_icon(self, symbol: str) -> QIcon:
+    def _convert_string_to_icon(self, symbol: str) -> QIcon:
+        """Create a QIcon from a string."""
         size = self._toggle_btn.font().pointSize()
         pixmap = QPixmap(size, size)
         pixmap.fill(Qt.transparent)
@@ -96,27 +97,33 @@ class QCollapsible(QFrame):
 
     def setExpandedIcon(self, icon: Optional[Union[QIcon, str]] = None):
         """Set the icon on the toggle button when the widget is expanded."""
-
         if icon and isinstance(icon, QIcon):
             self._expanded_icon = icon
         elif icon and isinstance(icon, str):
-            self._expanded_icon = self._convert_symbol_to_icon(icon)
+            self._expanded_icon = self._convert_string_to_icon(icon)
         else:
             symbol = "▼"
-            self._expanded_icon = self._convert_symbol_to_icon(symbol)
+            self._expanded_icon = self._convert_string_to_icon(symbol)
+
+    def expandedIcon(self):
+        """Returns the icon used when the widget is expanded."""
+        return self._expanded_icon
 
     def setCollapsedIcon(self, icon: Optional[Union[QIcon, str]] = None):
         """Set the icon on the toggle button when the widget is collapsed."""
-
         if icon and isinstance(icon, QIcon):
             self._collapsed_icon = icon
         elif icon and isinstance(icon, str):
-            self._collapsed_icon = self._convert_symbol_to_icon(icon)
+            self._collapsed_icon = self._convert_string_to_icon(icon)
         else:
             symbol = "▲"
-            self._collapsed_icon = self._convert_symbol_to_icon(symbol)
+            self._collapsed_icon = self._convert_string_to_icon(symbol)
 
         self._toggle_btn.setIcon(self._collapsed_icon)
+
+    def collapsedIcon(self):
+        """Returns the icon used when the widget is collapsed."""
+        return self._collapsed_icon
 
     def setDuration(self, msecs: int):
         """Set duration of the collapse/expand animation."""

--- a/src/superqt/collapsible/_collapsible.py
+++ b/src/superqt/collapsible/_collapsible.py
@@ -29,8 +29,8 @@ class QCollapsible(QFrame):
         self,
         title: str = "",
         parent: Optional[QWidget] = None,
-        expandedIcon: Optional[Union[QIcon, str]] = None,
-        collapsedIcon: Optional[Union[QIcon, str]] = None,
+        expandedIcon: Optional[Union[QIcon, str]] = "▼",
+        collapsedIcon: Optional[Union[QIcon, str]] = "▲",
     ):
         super().__init__(parent)
         self._locked = False
@@ -101,9 +101,6 @@ class QCollapsible(QFrame):
             self._expanded_icon = icon
         elif icon and isinstance(icon, str):
             self._expanded_icon = self._convert_string_to_icon(icon)
-        else:
-            symbol = "▼"
-            self._expanded_icon = self._convert_string_to_icon(symbol)
 
     def expandedIcon(self):
         """Returns the icon used when the widget is expanded."""
@@ -115,9 +112,6 @@ class QCollapsible(QFrame):
             self._collapsed_icon = icon
         elif icon and isinstance(icon, str):
             self._collapsed_icon = self._convert_string_to_icon(icon)
-        else:
-            symbol = "▲"
-            self._collapsed_icon = self._convert_string_to_icon(symbol)
 
         self._toggle_btn.setIcon(self._collapsed_icon)
 

--- a/src/superqt/collapsible/_collapsible.py
+++ b/src/superqt/collapsible/_collapsible.py
@@ -28,7 +28,13 @@ class QCollapsible(QFrame):
 
     toggled = Signal(bool)
 
-    def __init__(self, title: str = "", parent: Optional[QWidget] = None):
+    def __init__(
+        self,
+        title: str = "",
+        parent: Optional[QWidget] = None,
+        expandedIcon: Optional[QIcon] = None,
+        collapsedIcon: Optional[QIcon] = None,
+    ):
         super().__init__(parent)
         self._locked = False
         self._is_animating = False
@@ -36,8 +42,8 @@ class QCollapsible(QFrame):
 
         self._toggle_btn = QPushButton(title)
         self._toggle_btn.setCheckable(True)
-        self.set_collapsed_icon()
-        self.set_expanded_icon()
+        self.setCollapsedIcon(icon=collapsedIcon)
+        self.setExpandedIcon(icon=expandedIcon)
         self._toggle_btn.setStyleSheet("text-align: left; border: none; outline: none;")
         self._toggle_btn.toggled.connect(self._toggle)
 
@@ -80,45 +86,33 @@ class QCollapsible(QFrame):
         """Return the current content widget."""
         return self._content
 
-    def set_expanded_icon(self, icon=None):
+    def _convert_symbol_to_icon(self, symbol: str) -> QIcon:
+        pixmap = QPixmap(16, 16)
+        pixmap.fill(Qt.transparent)
+        painter = QPainter(pixmap)
+        color = self._toggle_btn.palette().color(QPalette.WindowText)
+        painter.setPen(color)
+        painter.drawText(QRect(0, 0, 16, 16), Qt.AlignCenter, symbol)
+        painter.end()
+        return QIcon(pixmap)
+
+    def setExpandedIcon(self, icon=None):
         """Set the icon on the toggle button when the widget is expanded."""
 
-        if icon:
+        if icon and isinstance(icon, QIcon):
             self._EXPANDED = icon
         else:
-            pixmap = QPixmap(16, 16)
-            pixmap.fill(Qt.transparent)
-            painter = QPainter(pixmap)
-            color = self._toggle_btn.palette().color(QPalette.WindowText)
-            painter.setPen(color)
             symbol = "▼"
-            painter.drawText(QRect(0, 0, 16, 16), Qt.AlignCenter, symbol)
-            painter.end()
+            self._EXPANDED = self._convert_symbol_to_icon(symbol)
 
-            self._EXPANDED = QIcon(pixmap)
-
-            del painter
-            del pixmap
-
-    def set_collapsed_icon(self, icon=None):
+    def setCollapsedIcon(self, icon=None):
         """Set the icon on the toggle button when the widget is collapsed."""
 
-        if icon:
+        if icon and isinstance(icon, QIcon):
             self._COLLAPSED = icon
         else:
-            pixmap = QPixmap(16, 16)
-            pixmap.fill(Qt.transparent)
-            painter = QPainter(pixmap)
-            color = self._toggle_btn.palette().color(QPalette.WindowText)
-            painter.setPen(color)
             symbol = "▲"
-            painter.drawText(QRect(0, 0, 16, 16), Qt.AlignCenter, symbol)
-            painter.end()
-
-            self._COLLAPSED = QIcon(pixmap)
-
-            del painter
-            del pixmap
+            self._COLLAPSED = self._convert_symbol_to_icon(symbol)
 
         self._toggle_btn.setIcon(self._COLLAPSED)
 

--- a/src/superqt/collapsible/_collapsible.py
+++ b/src/superqt/collapsible/_collapsible.py
@@ -63,12 +63,12 @@ class QCollapsible(QFrame):
 
     def setText(self, text: str):
         """Set the text of the toggle button."""
-        current = self._toggle_btn.text()[: len(self._EXPANDED)]
+        current = self._toggle_btn.text()
         self._toggle_btn.setText(current + text)
 
     def text(self) -> str:
         """Return the text of the toggle button."""
-        return self._toggle_btn.text()[len(self._EXPANDED) :]
+        return self._toggle_btn.text()
 
     def setContent(self, content: QWidget):
         """Replace central widget (the widget that gets expanded/collapsed)."""

--- a/src/superqt/collapsible/_collapsible.py
+++ b/src/superqt/collapsible/_collapsible.py
@@ -87,12 +87,13 @@ class QCollapsible(QFrame):
         return self._content
 
     def _convert_symbol_to_icon(self, symbol: str) -> QIcon:
-        pixmap = QPixmap(16, 16)
+        size = self._toggle_btn.font().pointSize()
+        pixmap = QPixmap(size, size)
         pixmap.fill(Qt.transparent)
         painter = QPainter(pixmap)
         color = self._toggle_btn.palette().color(QPalette.WindowText)
         painter.setPen(color)
-        painter.drawText(QRect(0, 0, 16, 16), Qt.AlignCenter, symbol)
+        painter.drawText(QRect(0, 0, size, size), Qt.AlignCenter, symbol)
         painter.end()
         return QIcon(pixmap)
 

--- a/src/superqt/collapsible/_collapsible.py
+++ b/src/superqt/collapsible/_collapsible.py
@@ -23,9 +23,6 @@ class QCollapsible(QFrame):
     Based on https://stackoverflow.com/a/68141638
     """
 
-    _expanded_icon = "▼  "
-    _collapsed_icon = "▲  "
-
     toggled = Signal(bool)
 
     def __init__(

--- a/src/superqt/collapsible/_collapsible.py
+++ b/src/superqt/collapsible/_collapsible.py
@@ -1,5 +1,5 @@
 """A collapsible widget to hide and unhide child widgets"""
-from typing import Optional
+from typing import Optional, Union
 
 from qtpy.QtCore import (
     QEasingCurve,
@@ -32,8 +32,8 @@ class QCollapsible(QFrame):
         self,
         title: str = "",
         parent: Optional[QWidget] = None,
-        expandedIcon: Optional[QIcon] = None,
-        collapsedIcon: Optional[QIcon] = None,
+        expandedIcon: Optional[Union[QIcon, str]] = None,
+        collapsedIcon: Optional[Union[QIcon, str]] = None,
     ):
         super().__init__(parent)
         self._locked = False
@@ -96,20 +96,24 @@ class QCollapsible(QFrame):
         painter.end()
         return QIcon(pixmap)
 
-    def setExpandedIcon(self, icon=None):
+    def setExpandedIcon(self, icon: Optional[Union[QIcon, str]] = None):
         """Set the icon on the toggle button when the widget is expanded."""
 
         if icon and isinstance(icon, QIcon):
             self._EXPANDED = icon
+        elif icon and isinstance(icon, str):
+            self._EXPANDED = self._convert_symbol_to_icon(icon)
         else:
             symbol = "▼"
             self._EXPANDED = self._convert_symbol_to_icon(symbol)
 
-    def setCollapsedIcon(self, icon=None):
+    def setCollapsedIcon(self, icon: Optional[Union[QIcon, str]] = None):
         """Set the icon on the toggle button when the widget is collapsed."""
 
         if icon and isinstance(icon, QIcon):
             self._COLLAPSED = icon
+        elif icon and isinstance(icon, str):
+            self._COLLAPSED = self._convert_symbol_to_icon(icon)
         else:
             symbol = "▲"
             self._COLLAPSED = self._convert_symbol_to_icon(symbol)

--- a/src/superqt/collapsible/_collapsible.py
+++ b/src/superqt/collapsible/_collapsible.py
@@ -9,7 +9,9 @@ from qtpy.QtCore import (
     QPropertyAnimation,
     Qt,
     Signal,
+    QRect,
 )
+from qtpy.QtGui import QIcon, QPainter, QPalette, QPixmap
 from qtpy.QtWidgets import QFrame, QPushButton, QVBoxLayout, QWidget
 
 
@@ -30,9 +32,13 @@ class QCollapsible(QFrame):
         super().__init__(parent)
         self._locked = False
         self._is_animating = False
+        self._text = title
 
-        self._toggle_btn = QPushButton(self._COLLAPSED + title)
+        self._toggle_btn = QPushButton(title)
         self._toggle_btn.setCheckable(True)
+        self.set_collapsed_icon()
+        self.set_expanded_icon()
+        self._toggle_btn.setIcon(self._COLLAPSED)
         self._toggle_btn.setStyleSheet("text-align: left; border: none; outline: none;")
         self._toggle_btn.toggled.connect(self._toggle)
 
@@ -74,6 +80,46 @@ class QCollapsible(QFrame):
     def content(self) -> QWidget:
         """Return the current content widget."""
         return self._content
+
+    def set_expanded_icon(self, icon=None):
+        """Set the icon on the toggle button when the widget is expanded."""
+
+        if icon:
+            self._EXPANDED = icon
+        else:
+            pixmap = QPixmap(16, 16)
+            pixmap.fill(Qt.transparent)
+            painter = QPainter(pixmap)
+            color = self._toggle_btn.palette().color(QPalette.WindowText)
+            painter.setPen(color)
+            symbol = "▼"
+            painter.drawText(QRect(0, 0, 16, 16), Qt.AlignCenter, symbol)
+            painter.end()
+
+            self._EXPANDED = QIcon(pixmap)
+
+            del painter
+            del pixmap
+
+    def set_collapsed_icon(self, icon=None):
+        """Set the icon on the toggle button when the widget is collapsed."""
+
+        if icon:
+            self._COLLAPSED = icon
+        else:
+            pixmap = QPixmap(16, 16)
+            pixmap.fill(Qt.transparent)
+            painter = QPainter(pixmap)
+            color = self._toggle_btn.palette().color(QPalette.WindowText)
+            painter.setPen(color)
+            symbol = "▲"
+            painter.drawText(QRect(0, 0, 16, 16), Qt.AlignCenter, symbol)
+            painter.end()
+
+            self._COLLAPSED = QIcon(pixmap)
+
+            del painter
+            del pixmap
 
     def setDuration(self, msecs: int):
         """Set duration of the collapse/expand animation."""
@@ -122,9 +168,9 @@ class QCollapsible(QFrame):
 
         forward = direction == QPropertyAnimation.Direction.Forward
         text = self._EXPANDED if forward else self._COLLAPSED
+        self._toggle_btn.setIcon(text)
 
         self._toggle_btn.setChecked(forward)
-        self._toggle_btn.setText(text + self._toggle_btn.text()[len(self._EXPANDED) :])
 
         _content_height = self._content.sizeHint().height() + 10
         if animate:

--- a/src/superqt/collapsible/_collapsible.py
+++ b/src/superqt/collapsible/_collapsible.py
@@ -7,9 +7,9 @@ from qtpy.QtCore import (
     QMargins,
     QObject,
     QPropertyAnimation,
+    QRect,
     Qt,
     Signal,
-    QRect,
 )
 from qtpy.QtGui import QIcon, QPainter, QPalette, QPixmap
 from qtpy.QtWidgets import QFrame, QPushButton, QVBoxLayout, QWidget
@@ -23,8 +23,8 @@ class QCollapsible(QFrame):
     Based on https://stackoverflow.com/a/68141638
     """
 
-    _EXPANDED = "▼  "
-    _COLLAPSED = "▲  "
+    _expanded_icon = "▼  "
+    _collapsed_icon = "▲  "
 
     toggled = Signal(bool)
 
@@ -101,25 +101,25 @@ class QCollapsible(QFrame):
         """Set the icon on the toggle button when the widget is expanded."""
 
         if icon and isinstance(icon, QIcon):
-            self._EXPANDED = icon
+            self._expanded_icon = icon
         elif icon and isinstance(icon, str):
-            self._EXPANDED = self._convert_symbol_to_icon(icon)
+            self._expanded_icon = self._convert_symbol_to_icon(icon)
         else:
             symbol = "▼"
-            self._EXPANDED = self._convert_symbol_to_icon(symbol)
+            self._expanded_icon = self._convert_symbol_to_icon(symbol)
 
     def setCollapsedIcon(self, icon: Optional[Union[QIcon, str]] = None):
         """Set the icon on the toggle button when the widget is collapsed."""
 
         if icon and isinstance(icon, QIcon):
-            self._COLLAPSED = icon
+            self._collapsed_icon = icon
         elif icon and isinstance(icon, str):
-            self._COLLAPSED = self._convert_symbol_to_icon(icon)
+            self._collapsed_icon = self._convert_symbol_to_icon(icon)
         else:
             symbol = "▲"
-            self._COLLAPSED = self._convert_symbol_to_icon(symbol)
+            self._collapsed_icon = self._convert_symbol_to_icon(symbol)
 
-        self._toggle_btn.setIcon(self._COLLAPSED)
+        self._toggle_btn.setIcon(self._collapsed_icon)
 
     def setDuration(self, msecs: int):
         """Set duration of the collapse/expand animation."""
@@ -167,7 +167,7 @@ class QCollapsible(QFrame):
             return
 
         forward = direction == QPropertyAnimation.Direction.Forward
-        text = self._EXPANDED if forward else self._COLLAPSED
+        text = self._expanded_icon if forward else self._collapsed_icon
         self._toggle_btn.setIcon(text)
 
         self._toggle_btn.setChecked(forward)

--- a/src/superqt/collapsible/_collapsible.py
+++ b/src/superqt/collapsible/_collapsible.py
@@ -64,7 +64,7 @@ class QCollapsible(QFrame):
         _content.layout().setContentsMargins(QMargins(5, 0, 0, 0))
         self.setContent(_content)
 
-    def setText(self, text: str):
+    def setText(self, text: str) -> None:
         """Set the text of the toggle button."""
         current = self._toggle_btn.text()
         self._toggle_btn.setText(current + text)
@@ -73,7 +73,7 @@ class QCollapsible(QFrame):
         """Return the text of the toggle button."""
         return self._toggle_btn.text()
 
-    def setContent(self, content: QWidget):
+    def setContent(self, content: QWidget) -> None:
         """Replace central widget (the widget that gets expanded/collapsed)."""
         self._content = content
         self.layout().addWidget(self._content)
@@ -87,61 +87,65 @@ class QCollapsible(QFrame):
         """Create a QIcon from a string."""
         size = self._toggle_btn.font().pointSize()
         pixmap = QPixmap(size, size)
-        pixmap.fill(Qt.transparent)
+        pixmap.fill(Qt.GlobalColor.transparent)
         painter = QPainter(pixmap)
-        color = self._toggle_btn.palette().color(QPalette.WindowText)
+        color = self._toggle_btn.palette().color(QPalette.ColorRole.WindowText)
         painter.setPen(color)
-        painter.drawText(QRect(0, 0, size, size), Qt.AlignCenter, symbol)
+        painter.drawText(QRect(0, 0, size, size), Qt.AlignmentFlag.AlignCenter, symbol)
         painter.end()
         return QIcon(pixmap)
 
-    def setExpandedIcon(self, icon: Optional[Union[QIcon, str]] = None):
+    def expandedIcon(self) -> QIcon:
+        """Returns the icon used when the widget is expanded."""
+        return self._expanded_icon
+
+    def setExpandedIcon(self, icon: Optional[Union[QIcon, str]] = None) -> None:
         """Set the icon on the toggle button when the widget is expanded."""
         if icon and isinstance(icon, QIcon):
             self._expanded_icon = icon
         elif icon and isinstance(icon, str):
             self._expanded_icon = self._convert_string_to_icon(icon)
 
-    def expandedIcon(self):
-        """Returns the icon used when the widget is expanded."""
-        return self._expanded_icon
+        if self.isExpanded():
+            self._toggle_btn.setIcon(self._expanded_icon)
 
-    def setCollapsedIcon(self, icon: Optional[Union[QIcon, str]] = None):
+    def collapsedIcon(self) -> QIcon:
+        """Returns the icon used when the widget is collapsed."""
+        return self._collapsed_icon
+
+    def setCollapsedIcon(self, icon: Optional[Union[QIcon, str]] = None) -> None:
         """Set the icon on the toggle button when the widget is collapsed."""
         if icon and isinstance(icon, QIcon):
             self._collapsed_icon = icon
         elif icon and isinstance(icon, str):
             self._collapsed_icon = self._convert_string_to_icon(icon)
 
-        self._toggle_btn.setIcon(self._collapsed_icon)
+        if not self.isExpanded():
+            self._toggle_btn.setIcon(self._collapsed_icon)
 
-    def collapsedIcon(self):
-        """Returns the icon used when the widget is collapsed."""
-        return self._collapsed_icon
-
-    def setDuration(self, msecs: int):
+    def setDuration(self, msecs: int) -> None:
         """Set duration of the collapse/expand animation."""
         self._animation.setDuration(msecs)
 
-    def setEasingCurve(self, easing: QEasingCurve):
+    def setEasingCurve(self, easing: QEasingCurve) -> None:
         """Set the easing curve for the collapse/expand animation"""
         self._animation.setEasingCurve(easing)
 
-    def addWidget(self, widget: QWidget):
+    def addWidget(self, widget: QWidget) -> None:
         """Add a widget to the central content widget's layout."""
         widget.installEventFilter(self)
         self._content.layout().addWidget(widget)
 
-    def removeWidget(self, widget: QWidget):
+    def removeWidget(self, widget: QWidget) -> None:
         """Remove widget from the central content widget's layout."""
         self._content.layout().removeWidget(widget)
         widget.removeEventFilter(self)
 
-    def expand(self, animate: bool = True):
+    def expand(self, animate: bool = True) -> None:
         """Expand (show) the collapsible section"""
         self._expand_collapse(QPropertyAnimation.Direction.Forward, animate)
 
-    def collapse(self, animate: bool = True):
+    def collapse(self, animate: bool = True) -> None:
         """Collapse (hide) the collapsible section"""
         self._expand_collapse(QPropertyAnimation.Direction.Backward, animate)
 
@@ -149,7 +153,7 @@ class QCollapsible(QFrame):
         """Return whether the collapsible section is visible"""
         return self._toggle_btn.isChecked()
 
-    def setLocked(self, locked: bool = True):
+    def setLocked(self, locked: bool = True) -> None:
         """Set whether collapse/expand is disabled"""
         self._locked = locked
         self._toggle_btn.setCheckable(not locked)
@@ -160,14 +164,13 @@ class QCollapsible(QFrame):
 
     def _expand_collapse(
         self, direction: QPropertyAnimation.Direction, animate: bool = True
-    ):
+    ) -> None:
         if self._locked:
             return
 
         forward = direction == QPropertyAnimation.Direction.Forward
-        text = self._expanded_icon if forward else self._collapsed_icon
-        self._toggle_btn.setIcon(text)
-
+        icon = self._expanded_icon if forward else self._collapsed_icon
+        self._toggle_btn.setIcon(icon)
         self._toggle_btn.setChecked(forward)
 
         _content_height = self._content.sizeHint().height() + 10
@@ -181,7 +184,7 @@ class QCollapsible(QFrame):
 
         self.toggled.emit(direction == QPropertyAnimation.Direction.Forward)
 
-    def _toggle(self):
+    def _toggle(self) -> None:
         self.expand() if self.isExpanded() else self.collapse()
 
     def eventFilter(self, a0: QObject, a1: QEvent) -> bool:
@@ -194,5 +197,5 @@ class QCollapsible(QFrame):
             self._expand_collapse(QPropertyAnimation.Direction.Forward, animate=False)
         return False
 
-    def _on_animation_done(self):
+    def _on_animation_done(self) -> None:
         self._is_animating = False

--- a/tests/test_collapsible.py
+++ b/tests/test_collapsible.py
@@ -1,12 +1,32 @@
 """A test module for testing collapsible"""
+from pathlib import Path
 
 import pytest
 from qtpy.QtCore import QEasingCurve,  Qt
-from fonticon_fa5 import FA5S
 from qtpy.QtWidgets import QPushButton
 
 from superqt import QCollapsible
 from superqt.fonticon import icon
+from superqt.fonticon._qfont_icon import QFontIconStore
+
+TEST_PREFIX = "ico"
+TEST_CHARNAME = "smiley"
+TEST_CHAR = "\ue900"
+TEST_GLYPHKEY = f"{TEST_PREFIX}.{TEST_CHARNAME}"
+FONT_FILE = Path(__file__).parent / "test_fonticon/icontest.ttf"
+
+
+@pytest.fixture
+def store(qapp):
+    store = QFontIconStore().instance()
+    yield store
+    store.clear()
+
+
+@pytest.fixture
+def full_store(store):
+    store.addFont(str(FONT_FILE), TEST_PREFIX, {TEST_CHARNAME: TEST_CHAR})
+    return store
 
 
 def test_checked_initialization(qtbot):
@@ -103,11 +123,10 @@ def test_toggle_signal(qtbot):
     
 
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
-def test_setting_icon(qtbot):
+def test_setting_icon(qtbot, full_store):
     """Test setting icon for toggle button."""
-
-    icon1 = icon(FA5S.smile, color="white")
-    icon2 = icon(FA5S.frown, color="white")
+    icon1 = icon(TEST_GLYPHKEY)
+    icon2 = icon(TEST_GLYPHKEY)
 
     wdg = QCollapsible("test", expandedIcon=icon1, collapsedIcon=icon2)
     assert wdg._EXPANDED == icon1

--- a/tests/test_collapsible.py
+++ b/tests/test_collapsible.py
@@ -1,11 +1,12 @@
 """A test module for testing collapsible"""
 
 import pytest
-from napari._qt.qt_resources import QColoredSVGIcon
 from qtpy.QtCore import QEasingCurve,  Qt
+from fonticon_fa5 import FA5S
 from qtpy.QtWidgets import QPushButton
 
 from superqt import QCollapsible
+from superqt.fonticon import icon
 
 
 def test_checked_initialization(qtbot):
@@ -105,12 +106,12 @@ def test_toggle_signal(qtbot):
 def test_setting_icon(qtbot):
     """Test setting icon for toggle button."""
 
-    icon1 = QColoredSVGIcon.from_resources("right_arrow")
-    icon2 = QColoredSVGIcon.from_resources("right_arrow")
+    icon1 = icon(FA5S.smile, color="white")
+    icon2 = icon(FA5S.frown, color="white")
 
-    wdg = QCollapsible("test", expandedIcon=icon2, collapsedIcon=icon1)
-    assert wdg._EXPANDED == icon2
-    assert wdg._COLLAPSED == icon1
+    wdg = QCollapsible("test", expandedIcon=icon1, collapsedIcon=icon2)
+    assert wdg._EXPANDED == icon1
+    assert wdg._COLLAPSED == icon2
 
     icon2 = wdg._convert_symbol_to_icon("*")
     wdg.setCollapsedIcon(icon=icon2)

--- a/tests/test_collapsible.py
+++ b/tests/test_collapsible.py
@@ -84,8 +84,7 @@ def test_changing_text(qtbot):
     wdg = QCollapsible()
     wdg.setText("Hi new text")
     assert wdg.text() == "Hi new text"
-    assert wdg._toggle_btn.text() == QCollapsible._COLLAPSED + "Hi new text"
-
+    assert wdg._toggle_btn.text() == "Hi new text"
 
 def test_toggle_signal(qtbot):
     """Test that signal is emitted when widget expanded/collapsed."""
@@ -98,3 +97,4 @@ def test_toggle_signal(qtbot):
 
     with qtbot.waitSignal(wdg.toggled, timeout=500):
         wdg.collapse()
+    

--- a/tests/test_collapsible.py
+++ b/tests/test_collapsible.py
@@ -2,6 +2,7 @@
 
 import pytest
 from qtpy.QtCore import QEasingCurve, Qt
+from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import QPushButton, QStyle, QWidget
 
 from superqt import QCollapsible
@@ -116,8 +117,8 @@ def test_toggle_signal(qtbot):
 def test_getting_icon(qtbot):
     """Test setting string as toggle button."""
     wdg = QCollapsible("test")
-    wdg.expandedIcon()
-    wdg.collapsedIcon()
+    assert isinstance(wdg.expandedIcon(), QIcon)
+    assert isinstance(wdg.collapsedIcon(), QIcon)
 
 
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")

--- a/tests/test_collapsible.py
+++ b/tests/test_collapsible.py
@@ -1,9 +1,7 @@
 """A test module for testing collapsible"""
 
 import pytest
-from qtpy.QtCore import QEasingCurve,  Qt
-from qtpy.QtWidgets import QPushButton
-from qtpy import PYQT6, PYSIDE6
+from qtpy.QtCore import QEasingCurve, Qt
 from qtpy.QtWidgets import QPushButton, QStyle, QWidget
 
 from superqt import QCollapsible
@@ -12,9 +10,9 @@ from superqt import QCollapsible
 def _get_builtin_icon(name):
     """Get a built-in icon from the Qt library."""
     widget = QWidget()
-    if PYQT6 or PYSIDE6:
+    try:
         pixmap = getattr(QStyle.StandardPixmap, f"SP_{name}")
-    else:
+    except AttributeError:
         pixmap = getattr(QStyle, f"SP_{name}")
 
     return widget.style().standardIcon(pixmap)
@@ -100,6 +98,7 @@ def test_changing_text(qtbot):
     assert wdg.text() == "Hi new text"
     assert wdg._toggle_btn.text() == "Hi new text"
 
+
 def test_toggle_signal(qtbot):
     """Test that signal is emitted when widget expanded/collapsed."""
     wdg = QCollapsible()
@@ -111,7 +110,7 @@ def test_toggle_signal(qtbot):
 
     with qtbot.waitSignal(wdg.toggled, timeout=500):
         wdg.collapse()
-    
+
 
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_setting_icon(qtbot):
@@ -119,8 +118,8 @@ def test_setting_icon(qtbot):
     icon1 = _get_builtin_icon("ArrowRight")
     icon2 = _get_builtin_icon("ArrowDown")
     wdg = QCollapsible("test", expandedIcon=icon1, collapsedIcon=icon2)
-    assert wdg._EXPANDED == icon1
-    assert wdg._COLLAPSED == icon2
+    assert wdg._expanded_icon == icon1
+    assert wdg._collapsed_icon == icon2
 
 
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
@@ -130,6 +129,6 @@ def test_setting_symbol_icon(qtbot):
     icon1 = wdg._convert_symbol_to_icon("+")
     icon2 = wdg._convert_symbol_to_icon("-")
     wdg.setCollapsedIcon(icon=icon1)
-    assert wdg._COLLAPSED == icon1
+    assert wdg._collapsed_icon == icon1
     wdg.setExpandedIcon(icon=icon2)
-    assert wdg._EXPANDED == icon2
+    assert wdg._expanded_icon == icon2

--- a/tests/test_collapsible.py
+++ b/tests/test_collapsible.py
@@ -125,6 +125,7 @@ def test_setting_icon(qtbot):
 
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_setting_symbol_icon(qtbot):
+    """Test setting string as toggle button."""
     wdg = QCollapsible("test")
     icon1 = wdg._convert_symbol_to_icon("+")
     icon2 = wdg._convert_symbol_to_icon("-")

--- a/tests/test_collapsible.py
+++ b/tests/test_collapsible.py
@@ -1,6 +1,8 @@
 """A test module for testing collapsible"""
 
-from qtpy.QtCore import QEasingCurve, Qt
+import pytest
+from napari._qt.qt_resources import QColoredSVGIcon
+from qtpy.QtCore import QEasingCurve,  Qt
 from qtpy.QtWidgets import QPushButton
 
 from superqt import QCollapsible
@@ -98,3 +100,20 @@ def test_toggle_signal(qtbot):
     with qtbot.waitSignal(wdg.toggled, timeout=500):
         wdg.collapse()
     
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_setting_icon(qtbot):
+    """Test setting icon for toggle button."""
+
+    icon1 = QColoredSVGIcon.from_resources("right_arrow")
+    icon2 = QColoredSVGIcon.from_resources("right_arrow")
+
+    wdg = QCollapsible("test", expandedIcon=icon2, collapsedIcon=icon1)
+    assert wdg._EXPANDED == icon2
+    assert wdg._COLLAPSED == icon1
+
+    icon2 = wdg._convert_symbol_to_icon("*")
+    wdg.setCollapsedIcon(icon=icon2)
+    assert wdg._COLLAPSED == icon2
+    wdg.setExpandedIcon(icon=icon2)
+    assert wdg._EXPANDED == icon2

--- a/tests/test_collapsible.py
+++ b/tests/test_collapsible.py
@@ -113,6 +113,14 @@ def test_toggle_signal(qtbot):
 
 
 @pytest.mark.filterwarnings("ignore::DeprecationWarning")
+def test_getting_icon(qtbot):
+    """Test setting string as toggle button."""
+    wdg = QCollapsible("test")
+    wdg.expandedIcon()
+    wdg.collapsedIcon()
+
+
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_setting_icon(qtbot):
     """Test setting icon for toggle button."""
     icon1 = _get_builtin_icon("ArrowRight")

--- a/tests/test_collapsible.py
+++ b/tests/test_collapsible.py
@@ -1,6 +1,5 @@
 """A test module for testing collapsible"""
 
-import pytest
 from qtpy.QtCore import QEasingCurve, Qt
 from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import QPushButton, QStyle, QWidget
@@ -8,7 +7,7 @@ from qtpy.QtWidgets import QPushButton, QStyle, QWidget
 from superqt import QCollapsible
 
 
-def _get_builtin_icon(name):
+def _get_builtin_icon(name: str) -> QIcon:
     """Get a built-in icon from the Qt library."""
     widget = QWidget()
     try:
@@ -113,7 +112,6 @@ def test_toggle_signal(qtbot):
         wdg.collapse()
 
 
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_getting_icon(qtbot):
     """Test setting string as toggle button."""
     wdg = QCollapsible("test")
@@ -121,7 +119,6 @@ def test_getting_icon(qtbot):
     assert isinstance(wdg.collapsedIcon(), QIcon)
 
 
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_setting_icon(qtbot):
     """Test setting icon for toggle button."""
     icon1 = _get_builtin_icon("ArrowRight")
@@ -131,7 +128,6 @@ def test_setting_icon(qtbot):
     assert wdg._collapsed_icon == icon2
 
 
-@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_setting_symbol_icon(qtbot):
     """Test setting string as toggle button."""
     wdg = QCollapsible("test")

--- a/tests/test_collapsible.py
+++ b/tests/test_collapsible.py
@@ -126,8 +126,8 @@ def test_setting_icon(qtbot):
 def test_setting_symbol_icon(qtbot):
     """Test setting string as toggle button."""
     wdg = QCollapsible("test")
-    icon1 = wdg._convert_symbol_to_icon("+")
-    icon2 = wdg._convert_symbol_to_icon("-")
+    icon1 = wdg._convert_string_to_icon("+")
+    icon2 = wdg._convert_string_to_icon("-")
     wdg.setCollapsedIcon(icon=icon1)
     assert wdg._collapsed_icon == icon1
     wdg.setExpandedIcon(icon=icon2)

--- a/tests/test_fonticon/test_collapsible.py
+++ b/tests/test_fonticon/test_collapsible.py
@@ -13,7 +13,7 @@ TEST_PREFIX = "ico"
 TEST_CHARNAME = "smiley"
 TEST_CHAR = "\ue900"
 TEST_GLYPHKEY = f"{TEST_PREFIX}.{TEST_CHARNAME}"
-FONT_FILE = Path(__file__).parent / "test_fonticon/icontest.ttf"
+FONT_FILE = Path(__file__).parent / "icontest.ttf"
 
 
 @pytest.fixture


### PR DESCRIPTION
This PR adds the ability to change the icon on the toggle QPushButton.  Currently, the icon is a part of the text string.  This PR will change it so that an icon is set on the button.  The original icon is still used if there isn't one set, however, the default string is used to create an icon.  

You can now instantiate a collapsible widget while also declaring an `expandedIcon` and/or `collapsedIcon`.  These icons can be a QIcon or a text string.

```
icon1 = icon(FA5S.smile, color='white')
icon2 = icon(FA5S.frown, color='white')
collapsible = QCollapsible("Advanced analysis", expandedIcon=icon1, collapsedIcon=icon2)
```
<img width="294" alt="Screen Shot 2022-11-21 at 4 14 03 PM" src="https://user-images.githubusercontent.com/54282105/203170525-22c727ac-4989-46ed-b669-1a5e9a85fcc3.png">
<img width="294" alt="Screen Shot 2022-11-21 at 4 14 11 PM" src="https://user-images.githubusercontent.com/54282105/203170547-31621353-e680-495b-863f-d0b5d6a5f385.png">

```
collapsible = QCollapsible("Advanced analysis", expandedIcon='-', collapsedIcon="+")
```
<img width="293" alt="Screen Shot 2022-11-21 at 4 16 53 PM" src="https://user-images.githubusercontent.com/54282105/203170606-e4b98088-3082-452d-b538-df4b6c4d6fa5.png">
<img width="292" alt="Screen Shot 2022-11-21 at 4 16 46 PM" src="https://user-images.githubusercontent.com/54282105/203170616-caec7214-33d6-488d-8f79-c32d57e5f8cc.png">

