### PR TITLE
Add signal to QCollapsible

### DIFF
--- a/src/superqt/collapsible/_collapsible.py
+++ b/src/superqt/collapsible/_collapsible.py
@@ -1,7 +1,15 @@
 """A collapsible widget to hide and unhide child widgets"""
 from typing import Optional
 
-from qtpy.QtCore import QEasingCurve, QEvent, QMargins, QObject, QPropertyAnimation, Qt
+from qtpy.QtCore import (
+    QEasingCurve,
+    QEvent,
+    QMargins,
+    QObject,
+    QPropertyAnimation,
+    Qt,
+    Signal,
+)
 from qtpy.QtWidgets import QFrame, QPushButton, QVBoxLayout, QWidget
 
 
@@ -13,6 +21,8 @@ class QCollapsible(QFrame):
 
     _EXPANDED = "▼  "
     _COLLAPSED = "▲  "
+
+    toggled = Signal()
 
     def __init__(self, title: str = "", parent: Optional[QWidget] = None):
         super().__init__(parent)
@@ -125,6 +135,7 @@ class QCollapsible(QFrame):
 
     def _toggle(self):
         self.expand() if self.isExpanded() else self.collapse()
+        self.toggled.emit()
 
     def eventFilter(self, a0: QObject, a1: QEvent) -> bool:
         """If a child widget resizes, we need to update our expanded height."""

--- a/src/superqt/collapsible/_collapsible.py
+++ b/src/superqt/collapsible/_collapsible.py
@@ -16,13 +16,15 @@ from qtpy.QtWidgets import QFrame, QPushButton, QVBoxLayout, QWidget
 class QCollapsible(QFrame):
     """A collapsible widget to hide and unhide child widgets.
 
+    A signal is emitted when the widget is expanded (True) or collapsed (False).
+
     Based on https://stackoverflow.com/a/68141638
     """
 
     _EXPANDED = "▼  "
     _COLLAPSED = "▲  "
 
-    toggled = Signal()
+    toggled = Signal(bool)
 
     def __init__(self, title: str = "", parent: Optional[QWidget] = None):
         super().__init__(parent)
@@ -94,10 +96,12 @@ class QCollapsible(QFrame):
     def expand(self, animate: bool = True):
         """Expand (show) the collapsible section"""
         self._expand_collapse(QPropertyAnimation.Direction.Forward, animate)
+        self.toggled.emit(True)
 
     def collapse(self, animate: bool = True):
         """Collapse (hide) the collapsible section"""
         self._expand_collapse(QPropertyAnimation.Direction.Backward, animate)
+        self.toggled.emit(False)
 
     def isExpanded(self) -> bool:
         """Return whether the collapsible section is visible"""
@@ -135,7 +139,6 @@ class QCollapsible(QFrame):
 
     def _toggle(self):
         self.expand() if self.isExpanded() else self.collapse()
-        self.toggled.emit()
 
     def eventFilter(self, a0: QObject, a1: QEvent) -> bool:
         """If a child widget resizes, we need to update our expanded height."""

--- a/src/superqt/collapsible/_collapsible.py
+++ b/src/superqt/collapsible/_collapsible.py
@@ -96,12 +96,10 @@ class QCollapsible(QFrame):
     def expand(self, animate: bool = True):
         """Expand (show) the collapsible section"""
         self._expand_collapse(QPropertyAnimation.Direction.Forward, animate)
-        self.toggled.emit(True)
 
     def collapse(self, animate: bool = True):
         """Collapse (hide) the collapsible section"""
         self._expand_collapse(QPropertyAnimation.Direction.Backward, animate)
-        self.toggled.emit(False)
 
     def isExpanded(self) -> bool:
         """Return whether the collapsible section is visible"""
@@ -136,6 +134,8 @@ class QCollapsible(QFrame):
             self._animation.start()
         else:
             self._content.setMaximumHeight(_content_height if forward else 0)
+
+        self.toggled.emit(direction == QPropertyAnimation.Direction.Forward)
 
     def _toggle(self):
         self.expand() if self.isExpanded() else self.collapse()

--- a/tests/test_collapsible.py
+++ b/tests/test_collapsible.py
@@ -92,3 +92,9 @@ def test_toggle_signal(qtbot):
     wdg = QCollapsible()
     with qtbot.waitSignal(wdg.toggled, timeout=500):
         qtbot.mouseClick(wdg._toggle_btn, Qt.LeftButton)
+
+    with qtbot.waitSignal(wdg.toggled, timeout=500):
+        wdg.expand()
+
+    with qtbot.waitSignal(wdg.toggled, timeout=500):
+        wdg.collapse()

--- a/tests/test_collapsible.py
+++ b/tests/test_collapsible.py
@@ -1,6 +1,6 @@
 """A test module for testing collapsible"""
 
-from qtpy.QtCore import QEasingCurve
+from qtpy.QtCore import QEasingCurve, Qt
 from qtpy.QtWidgets import QPushButton
 
 from superqt import QCollapsible
@@ -85,3 +85,10 @@ def test_changing_text(qtbot):
     wdg.setText("Hi new text")
     assert wdg.text() == "Hi new text"
     assert wdg._toggle_btn.text() == QCollapsible._COLLAPSED + "Hi new text"
+
+
+def test_toggle_signal(qtbot):
+    """Test that signal is emitted when widget expanded/collapsed."""
+    wdg = QCollapsible()
+    with qtbot.waitSignal(wdg.toggled, timeout=500):
+        qtbot.mouseClick(wdg._toggle_btn, Qt.LeftButton)


### PR DESCRIPTION
This PR adds a signal that is emitted when the toggle button to expand/collapse the widget is pressed.  This signal was needed in https://github.com/napari/napari/pull/5198 in order to resize another widget when the collapsible widget expands/collapses.  