### PR TITLE
Move QCollapsible toggle signal emit

### DIFF
--- a/src/superqt/collapsible/_collapsible.py
+++ b/src/superqt/collapsible/_collapsible.py
@@ -132,10 +132,9 @@ class QCollapsible(QFrame):
             self._animation.setEndValue(_content_height)
             self._is_animating = True
             self._animation.start()
+            self.toggled.emit(direction == QPropertyAnimation.Direction.Forward)
         else:
             self._content.setMaximumHeight(_content_height if forward else 0)
-
-        self.toggled.emit(direction == QPropertyAnimation.Direction.Forward)
 
     def _toggle(self):
         self.expand() if self.isExpanded() else self.collapse()

--- a/src/superqt/collapsible/_collapsible.py
+++ b/src/superqt/collapsible/_collapsible.py
@@ -120,6 +120,11 @@ class QCollapsible(QFrame):
         animate: bool = True,
         emit: bool = True,
     ):
+        """Set values for the widget based on whether it is expanding or collapsing.
+
+        An emit flag is included so that the toggle signal is only called once (it
+        was being emitted a few times via eventFilter when the widget was expanding
+        previously)."""
         if self._locked:
             return
 

--- a/src/superqt/collapsible/_collapsible.py
+++ b/src/superqt/collapsible/_collapsible.py
@@ -115,7 +115,10 @@ class QCollapsible(QFrame):
         return self._locked
 
     def _expand_collapse(
-        self, direction: QPropertyAnimation.Direction, animate: bool = True
+        self,
+        direction: QPropertyAnimation.Direction,
+        animate: bool = True,
+        emit: bool = True,
     ):
         if self._locked:
             return
@@ -132,9 +135,10 @@ class QCollapsible(QFrame):
             self._animation.setEndValue(_content_height)
             self._is_animating = True
             self._animation.start()
-            self.toggled.emit(direction == QPropertyAnimation.Direction.Forward)
         else:
             self._content.setMaximumHeight(_content_height if forward else 0)
+        if emit:
+            self.toggled.emit(direction == QPropertyAnimation.Direction.Forward)
 
     def _toggle(self):
         self.expand() if self.isExpanded() else self.collapse()
@@ -146,7 +150,9 @@ class QCollapsible(QFrame):
             and self.isExpanded()
             and not self._is_animating
         ):
-            self._expand_collapse(QPropertyAnimation.Direction.Forward, animate=False)
+            self._expand_collapse(
+                QPropertyAnimation.Direction.Forward, animate=False, emit=False
+            )
         return False
 
     def _on_animation_done(self):


### PR DESCRIPTION
This PR will only emit the toggle signal when the animate flag is True.  I realized that the signal was being emitted 3 times when it was not inside the `animate` if statement.  I don't know if its needed when `animate = False`, but for my purposes, I would prefer if this signal is not emitted several times per mouse click.  