### PR TITLE
fix: fix pyside6 by removing typing

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -99,7 +99,7 @@ jobs:
           python -m pip install setuptools tox tox-gh-actions
 
       - name: Test with tox
-        uses: GabrielBB/xvfb-action@v1
+        uses: aganders3/headless-gui@v1
         timeout-minutes: 3
         with:
           run: python -m tox
@@ -116,7 +116,7 @@ jobs:
 
       - name: Screenshots (Linux)
         if: runner.os == 'Linux' && matrix.screenshot
-        uses: GabrielBB/xvfb-action@v1
+        uses: aganders3/headless-gui@v1
         with:
           run: python examples/demo_widget.py -snap
 
@@ -147,7 +147,7 @@ jobs:
           python -m pip install qtpy==1.1.0 typing-extensions==3.10.0.0
 
       - name: Test
-        uses: GabrielBB/xvfb-action@v1
+        uses: aganders3/headless-gui@v1
         with:
           run: python -m pytest --color=yes
 
@@ -178,7 +178,7 @@ jobs:
           python -m pip install ./napari-repo[testing,pyqt5]
 
       - name: Test napari
-        uses: GabrielBB/xvfb-action@v1
+        uses: aganders3/headless-gui@v1
         with:
           working-directory: napari-repo
           run: python -m pytest --color=yes napari/_qt

--- a/src/superqt/sliders/_generic_range_slider.py
+++ b/src/superqt/sliders/_generic_range_slider.py
@@ -1,6 +1,6 @@
 from typing import List, Optional, Sequence, Tuple, TypeVar, Union
 
-from qtpy import QtGui
+from qtpy import API, QtGui
 from qtpy.QtCore import Property, QEvent, QPoint, QPointF, QRect, QRectF, Qt, Signal
 from qtpy.QtWidgets import QSlider, QStyle, QStyleOptionSlider, QStylePainter
 
@@ -210,8 +210,15 @@ class _GenericRangeSlider(_GenericSlider):
     def _setBarColor(self, color):
         self._style.brush_active = color
 
-    barColor = Property(QtGui.QBrush, _getBarColor, _setBarColor)
-    """The color of the bar between the first and last handle."""
+    # FIXME:
+    # without this, I'm getting:
+    # gc:0: ResourceWarning: gc: 1 uncollectable objects at shutdown
+    #   [<PySide6.QtCore.Property object at ...>]
+    if API != "pyside6":
+        barColor = Property(QtGui.QBrush, _getBarColor, _setBarColor)
+        """The color of the bar between the first and last handle."""
+    else:
+        barColor = property(_getBarColor, _setBarColor)
 
     def _offsetAllPositions(self, offset: float, ref=None) -> None:
         if ref is None:

--- a/src/superqt/sliders/_generic_range_slider.py
+++ b/src/superqt/sliders/_generic_range_slider.py
@@ -17,7 +17,7 @@ _T = TypeVar("_T")
 SC_BAR = QStyle.SubControl.SC_ScrollBarSubPage
 
 
-class _GenericRangeSlider(_GenericSlider[Tuple], Generic[_T]):
+class _GenericRangeSlider(_GenericSlider):
     """MultiHandle Range Slider widget.
 
     Same API as QSlider, but `value`, `setValue`, `sliderPosition`, and

--- a/src/superqt/sliders/_generic_range_slider.py
+++ b/src/superqt/sliders/_generic_range_slider.py
@@ -1,4 +1,4 @@
-from typing import Generic, List, Optional, Sequence, Tuple, TypeVar, Union
+from typing import List, Optional, Sequence, Tuple, TypeVar, Union
 
 from qtpy import QtGui
 from qtpy.QtCore import Property, QEvent, QPoint, QPointF, QRect, QRectF, Qt, Signal

--- a/src/superqt/sliders/_generic_slider.py
+++ b/src/superqt/sliders/_generic_slider.py
@@ -21,7 +21,7 @@ QRangeSlider.
 """
 import os
 import platform
-from typing import Generic, TypeVar
+from typing import TypeVar
 
 from qtpy import QT_VERSION, QtGui
 from qtpy.QtCore import QEvent, QPoint, QPointF, QRect, Qt, Signal

--- a/src/superqt/sliders/_generic_slider.py
+++ b/src/superqt/sliders/_generic_slider.py
@@ -58,7 +58,7 @@ USE_MAC_SLIDER_PATCH = (
 )
 
 
-class _GenericSlider(QSlider, Generic[_T]):
+class _GenericSlider(QSlider):
     _fvalueChanged = Signal(int)
     _fsliderMoved = Signal(int)
     _frangeChanged = Signal(int, int)

--- a/src/superqt/sliders/_sliders.py
+++ b/src/superqt/sliders/_sliders.py
@@ -27,11 +27,11 @@ class _FloatMixin:
         return float(value)
 
 
-class QDoubleSlider(_FloatMixin, _GenericSlider[float]):
+class QDoubleSlider(_FloatMixin, _GenericSlider):
     pass
 
 
-class QIntSlider(_IntMixin, _GenericSlider[int]):
+class QIntSlider(_IntMixin, _GenericSlider):
     # mostly just an example... use QSlider instead.
     valueChanged = Signal(int)
 


### PR DESCRIPTION
frustratingly, it looks like I can no longer inherit from both `QSlider` and `typing.Generic` with pyside6 6.5

haven't had time to look into it farther, but this would fix stuff on pyside6