### PR TITLE
Searchable tree widget from a mapping

### DIFF
--- a/examples/searchable_tree_widget.py
+++ b/examples/searchable_tree_widget.py
@@ -22,8 +22,7 @@ data = {
 
 app = QApplication([])
 
-tree = QSearchableTreeWidget()
-tree.setData(data)
+tree = QSearchableTreeWidget.fromDict(data)
 tree.show()
 
 app.exec_()

--- a/examples/searchable_tree_widget.py
+++ b/examples/searchable_tree_widget.py
@@ -1,6 +1,12 @@
+import logging
 from qtpy.QtWidgets import QApplication
 
 from superqt import QSearchableTreeWidget
+
+logging.basicConfig(
+    level=logging.DEBUG,
+    format="%(asctime)s : %(levelname)s : %(filename)s : %(message)s"
+)
 
 data = {
     'kermit': 'favorite child',

--- a/examples/searchable_tree_widget.py
+++ b/examples/searchable_tree_widget.py
@@ -22,7 +22,7 @@ data = {
 
 app = QApplication([])
 
-tree = QSearchableTreeWidget.fromDict(data)
+tree = QSearchableTreeWidget.fromData(data)
 tree.show()
 
 app.exec_()

--- a/examples/searchable_tree_widget.py
+++ b/examples/searchable_tree_widget.py
@@ -17,6 +17,7 @@ data = {
     'dict': {
         'float': 0.5,
         'tuple': (22, 99),
+        'bool': False,
     },
 }
 

--- a/examples/searchable_tree_widget.py
+++ b/examples/searchable_tree_widget.py
@@ -10,15 +10,14 @@ logging.basicConfig(
 )
 
 data = {
-    "kermit": "favorite child",
-    "momo": ["loves", "to", "eat"],
-    "requests": {
-        "belly": "rubs",
-        "treats": "please",
-        "bowl": ["full", "of", "food"],
+    'none': None,
+    'str': 'test',
+    'int': 42,
+    'list': [2, 3, 5],
+    'dict': {
+        'float': 0.5,
+        'tuple': (22, 99),
     },
-    "cuteness": 10,
-    "sleep": None,
 }
 
 app = QApplication([])

--- a/examples/searchable_tree_widget.py
+++ b/examples/searchable_tree_widget.py
@@ -1,0 +1,23 @@
+from qtpy.QtWidgets import QApplication
+
+from superqt import QSearchableTreeWidget
+
+data = {
+    'kermit': 'favorite child',
+    'momo': ['loves', 'to', 'eat'],
+    'requests': {
+        'belly': 'rubs',
+        'treats': 'please',
+        'bowl': ['full', 'of', 'food'],
+    },
+    'cuteness': 10,
+    'sleep': None,
+}
+
+app = QApplication([])
+
+tree = QSearchableTreeWidget()
+tree.setData(data)
+tree.show()
+
+app.exec_()

--- a/examples/searchable_tree_widget.py
+++ b/examples/searchable_tree_widget.py
@@ -10,14 +10,14 @@ logging.basicConfig(
 )
 
 data = {
-    'none': None,
-    'str': 'test',
-    'int': 42,
-    'list': [2, 3, 5],
-    'dict': {
-        'float': 0.5,
-        'tuple': (22, 99),
-        'bool': False,
+    "none": None,
+    "str": "test",
+    "int": 42,
+    "list": [2, 3, 5],
+    "dict": {
+        "float": 0.5,
+        "tuple": (22, 99),
+        "bool": False,
     },
 }
 

--- a/src/superqt/__init__.py
+++ b/src/superqt/__init__.py
@@ -13,6 +13,7 @@ from ._eliding_label import QElidingLabel
 from .collapsible import QCollapsible
 from .combobox import QEnumComboBox, QSearchableComboBox
 from .selection import QSearchableListWidget
+from .selection import QSearchableTreeWidget
 from .sliders import (
     QDoubleRangeSlider,
     QDoubleSlider,
@@ -43,6 +44,7 @@ __all__ = [
     "QRangeSlider",
     "QSearchableComboBox",
     "QSearchableListWidget",
+    "QSearchableTreeWidget",
 ]
 
 

--- a/src/superqt/selection/__init__.py
+++ b/src/superqt/selection/__init__.py
@@ -1,3 +1,4 @@
 from ._searchable_list_widget import QSearchableListWidget
+from ._searchable_tree_widget import QSearchableTreeWidget
 
-__all__ = ("QSearchableListWidget",)
+__all__ = ("QSearchableListWidget", "QSearchableTreeWidget")

--- a/src/superqt/selection/_searchable_tree_widget.py
+++ b/src/superqt/selection/_searchable_tree_widget.py
@@ -20,7 +20,7 @@ class QSearchableTreeWidget(QWidget):
         layout.addWidget(self.tree_widget)
         self.setLayout(layout)
 
-    def _setData(self, data: dict) -> None:
+    def setData(self, data: dict) -> None:
         self.tree_widget.clear()
         top_level_items = [_to_item(k, v) for k, v in data.items()]
         self.tree_widget.addTopLevelItems(top_level_items)
@@ -34,7 +34,7 @@ class QSearchableTreeWidget(QWidget):
     @classmethod
     def fromDict(cls, data: dict, *, parent: QWidget = None) -> 'QSearchableTreeWidget':
         widget = cls(parent)
-        widget._setData(data)
+        widget.setData(data)
         return widget
 
 

--- a/src/superqt/selection/_searchable_tree_widget.py
+++ b/src/superqt/selection/_searchable_tree_widget.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Any, Tuple
 
 from qtpy.QtCore import Qt
@@ -26,6 +27,7 @@ class QSearchableTreeWidget(QWidget):
 
     def onlyShowMatchedItems(self, text: str) -> None:
         matched_items = tuple(self.tree_widget.findItems(text, Qt.MatchContains | Qt.MatchRecursive))
+        logging.debug('matched_items: %s', tuple(m.text(0) for m in matched_items))
         for i in range(self.tree_widget.topLevelItemCount()):
             top_level_item = self.tree_widget.topLevelItem(i)
             _only_show_matched_items(top_level_item, matched_items)
@@ -41,6 +43,7 @@ def _to_item(name: str, value: Any) -> QTreeWidgetItem:
         for i, v in enumerate(value):
             child = _to_item(str(i), v)
             item.addChild(child)
+    logging.debug('to_item: %s, %s', item.text(0), item.text(1))
     return item
 
 
@@ -49,6 +52,8 @@ def _only_show_matched_items(item: QTreeWidgetItem, matched_items: Tuple[QTreeWi
     for i in range(item.childCount()):
         child_item = item.child(i)
         child_item.setHidden(child_item not in matched_items)
-        is_hidden = is_hidden and _only_show_matched_items(child_item, matched_items)
+        are_descendants_hidden = _only_show_matched_items(child_item, matched_items)
+        is_hidden = is_hidden and are_descendants_hidden
     item.setHidden(is_hidden)
+    logging.debug('is_hidden: %s, %s', item.text(0), is_hidden)
     return is_hidden

--- a/src/superqt/selection/_searchable_tree_widget.py
+++ b/src/superqt/selection/_searchable_tree_widget.py
@@ -24,11 +24,12 @@ class QSearchableTreeWidget(QWidget):
         Used to filter items in the tree by matching their key against a
         regular expression.
     """
+
     def __init__(self, parent=None):
         super().__init__(parent)
 
         self.tree_widget = QTreeWidget()
-        self.tree_widget.setHeaderLabels(('Key', 'Value'))
+        self.tree_widget.setHeaderLabels(("Key", "Value"))
 
         self.filter_widget = QLineEdit()
         self.filter_widget.textChanged.connect(self._updateVisibleItems)
@@ -53,7 +54,9 @@ class QSearchableTreeWidget(QWidget):
             _update_visible_items(top_level_item, expression)
 
     @classmethod
-    def fromData(cls, data: Mapping, *, parent: QWidget = None) -> 'QSearchableTreeWidget':
+    def fromData(
+        cls, data: Mapping, *, parent: QWidget = None
+    ) -> "QSearchableTreeWidget":
         """Make a searchable tree widget from a mapping."""
         widget = cls(parent)
         widget.setData(data)
@@ -76,11 +79,13 @@ def _make_item(*, name: str, value: Any) -> QTreeWidgetItem:
         for i, v in enumerate(value):
             child = _make_item(name=str(i), value=v)
             item.addChild(child)
-    logging.debug('_make_item: %s, %s', item.text(0), item.text(1))
+    logging.debug("_make_item: %s, %s", item.text(0), item.text(1))
     return item
 
 
-def _update_visible_items(item: QTreeWidgetItem, expression: QRegularExpression, parent_visible: bool = False) -> bool:
+def _update_visible_items(
+    item: QTreeWidgetItem, expression: QRegularExpression, parent_visible: bool = False
+) -> bool:
     """Recursively update the visibility of a tree item based on a expression.
 
     An item is visible if it, its parent, or any of its descendants match the expression.
@@ -94,5 +99,5 @@ def _update_visible_items(item: QTreeWidgetItem, expression: QRegularExpression,
         descendants_visible = _update_visible_items(child, expression, visible)
         visible = visible or descendants_visible
     item.setHidden(not visible)
-    logging.debug('visible: %s, %s', text, visible)
+    logging.debug("visible: %s, %s", text, visible)
     return visible

--- a/src/superqt/selection/_searchable_tree_widget.py
+++ b/src/superqt/selection/_searchable_tree_widget.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Iterable, Mapping
 
-from qtpy.QtCore import QRegularExpression, Qt
+from qtpy.QtCore import QRegularExpression
 from qtpy.QtWidgets import QLineEdit, QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget
 
 
@@ -12,9 +12,11 @@ class QSearchableTreeWidget(QWidget):
     created using `QSearchableTreeWidget.fromData(data)`.
     If the mapping changes, the easiest way to update this is by calling `setData`.
 
-    The tree can be searched by entering a regular expression pattern.
-    into the `filter` line edit. An item is only shown if its, any of its ancestors,
+    The tree can be searched by entering a regular expression pattern
+    into the `filter` line edit. An item is only shown if its, any of its ancestors',
     or any of its descendants' keys or values match this pattern.
+    The regular expression follows the conventions described by the Qt docs:
+    https://doc.qt.io/qt-5/qregularexpression.html#details
 
     Attributes
     ----------
@@ -30,7 +32,6 @@ class QSearchableTreeWidget(QWidget):
 
         self.tree: QTreeWidget = QTreeWidget(self)
         self.tree.setHeaderLabels(("Key", "Value"))
-        self.tree.setUniformRowHeights(True)
 
         self.filter: QLineEdit = QLineEdit(self)
         self.filter.setClearButtonEnabled(True)
@@ -83,7 +84,6 @@ def _make_item(*, name: str, value: Any) -> QTreeWidgetItem:
             item.addChild(child)
     else:
         item = QTreeWidgetItem([name, str(value)])
-        item.setFlags(item.flags() | Qt.ItemNeverHasChildren)
     logging.debug("_make_item: %s, %s, %s", item.text(0), item.text(1), item.flags())
     return item
 

--- a/src/superqt/selection/_searchable_tree_widget.py
+++ b/src/superqt/selection/_searchable_tree_widget.py
@@ -53,16 +53,17 @@ def _to_item(name: str, value: Any) -> QTreeWidgetItem:
     return item
 
 
-def _update_visible_items(item: QTreeWidgetItem, expression: QRegularExpression) -> bool:
+def _update_visible_items(item: QTreeWidgetItem, expression: QRegularExpression, parent_visible: bool = False) -> bool:
     """Recursively update the visibility of a tree item by matching against a regular expression.
-    An item is visible if it or any of its descendants are visible.
+    An item is visible if it, its parent, or any of its descendants match the expression.
+    The text of the item's first column is used to match the expression.
     Returns True if the item is visible, False otherwise.
     """
     text = item.text(0)
-    visible = expression.match(text).hasMatch()
+    visible = parent_visible or expression.match(text).hasMatch()
     for i in range(item.childCount()):
         child = item.child(i)
-        descendants_visible = _update_visible_items(child, expression)
+        descendants_visible = _update_visible_items(child, expression, visible)
         visible = visible or descendants_visible
     item.setHidden(not visible)
     logging.debug('visible: %s, %s', text, visible)

--- a/src/superqt/selection/_searchable_tree_widget.py
+++ b/src/superqt/selection/_searchable_tree_widget.py
@@ -1,11 +1,29 @@
 import logging
-from typing import Any
+from typing import Any, Iterable, Mapping
 
 from qtpy.QtCore import QRegularExpression
 from qtpy.QtWidgets import QLineEdit, QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget
 
 
 class QSearchableTreeWidget(QWidget):
+    """A tree widget for showing a mapping that can be searched by key.
+
+    This is intended to be used with a read-only mapping and be conveniently
+    created using `QSearchableTreeWidget.fromMapping(data)`.
+    If the mapping changes, the easiest way to update this is by calling `setData`.
+
+    The tree can be searched by entering a regular expression pattern
+    into the `filter_widget` line edit. An item is only shown if its key
+    or any of its ancestors' or descendants' keys match this pattern.
+
+    Attributes
+    ----------
+    tree_widget : QTreeWidget
+        Shows the mapping as a tree of items.
+    filter_widget : QLineEdit
+        Used to filter items in the tree by matching their key against a
+        regular expression.
+    """
     def __init__(self, parent=None):
         super().__init__(parent)
 
@@ -20,41 +38,51 @@ class QSearchableTreeWidget(QWidget):
         layout.addWidget(self.tree_widget)
         self.setLayout(layout)
 
-    def setData(self, data: dict) -> None:
+    def setData(self, data: Mapping) -> None:
+        """Update the mapping data shown by the tree."""
         self.tree_widget.clear()
         self.filter_widget.clear()
-        top_level_items = [_to_item(k, v) for k, v in data.items()]
+        top_level_items = [_make_item(name=k, value=v) for k, v in data.items()]
         self.tree_widget.addTopLevelItems(top_level_items)
 
-    def _updateVisibleItems(self, text: str) -> None:
-        expression = QRegularExpression(text)
+    def _updateVisibleItems(self, pattern: str) -> None:
+        """Recursively update the visibility of the items in the tree based on the given pattern."""
+        expression = QRegularExpression(pattern)
         for i in range(self.tree_widget.topLevelItemCount()):
             top_level_item = self.tree_widget.topLevelItem(i)
             _update_visible_items(top_level_item, expression)
 
     @classmethod
-    def fromDict(cls, data: dict, *, parent: QWidget = None) -> 'QSearchableTreeWidget':
+    def fromData(cls, data: Mapping, *, parent: QWidget = None) -> 'QSearchableTreeWidget':
+        """Make a searchable tree widget from a mapping."""
         widget = cls(parent)
         widget.setData(data)
         return widget
 
 
-def _to_item(name: str, value: Any) -> QTreeWidgetItem:
+def _make_item(*, name: str, value: Any) -> QTreeWidgetItem:
+    """Make a tree item where the name and value are two columns.
+
+    Iterable values other than strings are recursively traversed to
+    add child items and build a tree. In this case, mappings use keys
+    as their names whereas other iterables use their enumerated index.
+    """
     item = QTreeWidgetItem((name, str(value)))
-    if isinstance(value, dict):
+    if isinstance(value, Mapping):
         for k, v in value.items():
-            child = _to_item(k, v)
+            child = _make_item(name=k, value=v)
             item.addChild(child)
-    elif isinstance(value, list):
+    elif isinstance(value, Iterable) and not isinstance(value, str):
         for i, v in enumerate(value):
-            child = _to_item(str(i), v)
+            child = _make_item(name=str(i), value=v)
             item.addChild(child)
-    logging.debug('to_item: %s, %s', item.text(0), item.text(1))
+    logging.debug('_make_item: %s, %s', item.text(0), item.text(1))
     return item
 
 
 def _update_visible_items(item: QTreeWidgetItem, expression: QRegularExpression, parent_visible: bool = False) -> bool:
-    """Recursively update the visibility of a tree item by matching against a regular expression.
+    """Recursively update the visibility of a tree item based on a expression.
+
     An item is visible if it, its parent, or any of its descendants match the expression.
     The text of the item's first column is used to match the expression.
     Returns True if the item is visible, False otherwise.

--- a/src/superqt/selection/_searchable_tree_widget.py
+++ b/src/superqt/selection/_searchable_tree_widget.py
@@ -22,6 +22,7 @@ class QSearchableTreeWidget(QWidget):
 
     def setData(self, data: dict) -> None:
         self.tree_widget.clear()
+        self.filter_widget.clear()
         top_level_items = [_to_item(k, v) for k, v in data.items()]
         self.tree_widget.addTopLevelItems(top_level_items)
 

--- a/src/superqt/selection/_searchable_tree_widget.py
+++ b/src/superqt/selection/_searchable_tree_widget.py
@@ -54,16 +54,16 @@ def _to_item(name: str, value: Any) -> QTreeWidgetItem:
 
 
 def _update_visible_items(item: QTreeWidgetItem, expression: QRegularExpression) -> bool:
-    """Show an item if the text of its first column is matched by the given regular expression.
-
-    Returns True if this item and all its descendants are hidden, False otherwise.
+    """Recursively update the visibility of a tree item by matching against a regular expression.
+    An item is visible if it or any of its descendants are visible.
+    Returns True if the item is visible, False otherwise.
     """
     text = item.text(0)
-    is_hidden = not expression.match(text).hasMatch()
+    visible = expression.match(text).hasMatch()
     for i in range(item.childCount()):
         child = item.child(i)
-        descendants_hidden = _update_visible_items(child, expression)
-        is_hidden = is_hidden and descendants_hidden
-    item.setHidden(is_hidden)
-    logging.debug('is_hidden: %s, %s', text, is_hidden)
-    return is_hidden
+        descendants_visible = _update_visible_items(child, expression)
+        visible = visible or descendants_visible
+    item.setHidden(not visible)
+    logging.debug('visible: %s, %s', text, visible)
+    return visible

--- a/src/superqt/selection/_searchable_tree_widget.py
+++ b/src/superqt/selection/_searchable_tree_widget.py
@@ -32,6 +32,12 @@ class QSearchableTreeWidget(QWidget):
             top_level_item = self.tree_widget.topLevelItem(i)
             _only_show_matched_items(top_level_item, matched_items)
 
+    @classmethod
+    def fromDict(cls, data: dict, *, parent: QWidget = None) -> 'QSearchableTreeWidget':
+        widget = cls(parent)
+        widget.setData(data)
+        return widget
+
 
 def _to_item(name: str, value: Any) -> QTreeWidgetItem:
     item = QTreeWidgetItem((name, str(value)))

--- a/src/superqt/selection/_searchable_tree_widget.py
+++ b/src/superqt/selection/_searchable_tree_widget.py
@@ -47,7 +47,7 @@ class QSearchableTreeWidget(QWidget):
         self.tree.addTopLevelItems(top_level_items)
 
     def _updateVisibleItems(self, pattern: str) -> None:
-        """Recursively update the visibility of the items in the tree based on the given pattern."""
+        """Recursively update the visibility of items based on the given pattern."""
         expression = QRegularExpression(pattern)
         for i in range(self.tree.topLevelItemCount()):
             top_level_item = self.tree.topLevelItem(i)

--- a/src/superqt/selection/_searchable_tree_widget.py
+++ b/src/superqt/selection/_searchable_tree_widget.py
@@ -9,12 +9,12 @@ class QSearchableTreeWidget(QWidget):
     """A tree widget for showing a mapping that can be searched by key.
 
     This is intended to be used with a read-only mapping and be conveniently
-    created using `QSearchableTreeWidget.fromMapping(data)`.
+    created using `QSearchableTreeWidget.fromData(data)`.
     If the mapping changes, the easiest way to update this is by calling `setData`.
 
-    The tree can be searched by entering a regular expression pattern
-    into the `filter` line edit. An item is only shown if its key
-    or any of its ancestors' or descendants' keys match this pattern.
+    The tree can be searched by entering a regular expression pattern.
+    into the `filter` line edit. An item is only shown if its, any of its ancestors,
+    or any of its descendants' keys or values match this pattern.
 
     Attributes
     ----------
@@ -93,18 +93,16 @@ def _update_visible_items(
 ) -> bool:
     """Recursively update the visibility of a tree item based on an expression.
 
-    An item is visible if it, any of its ancestors, or any of its descendants
-    match the expression.
-    The text of an item's first column is used to match the expression.
+    An item is visible if any of its, any of its ancestors', or any of its descendants'
+    column's text matches the expression.
     Returns True if the item is visible, False otherwise.
     """
-    text = item.text(0)
-    match = ancestor_match or expression.match(text).hasMatch()
+    match = ancestor_match or any(expression.match(item.text(i)).hasMatch() for i in range(item.columnCount()))
     visible = match
     for i in range(item.childCount()):
         child = item.child(i)
         descendant_visible = _update_visible_items(child, expression, match)
         visible = visible or descendant_visible
     item.setHidden(not visible)
-    logging.debug("_update_visible_items: %s, %s", text, visible)
+    logging.debug("_update_visible_items: %s, %s", tuple(item.text(i) for i in range(item.columnCount())), visible)
     return visible

--- a/src/superqt/selection/_searchable_tree_widget.py
+++ b/src/superqt/selection/_searchable_tree_widget.py
@@ -1,0 +1,54 @@
+from typing import Any, Tuple
+
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QLineEdit, QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget
+
+
+class QSearchableTreeWidget(QWidget):
+    def __init__(self, parent=None):
+        super().__init__(parent)
+
+        self.tree_widget = QTreeWidget()
+        self.tree_widget.setHeaderLabels(('Key', 'Value'))
+
+        self.filter_widget = QLineEdit()
+        self.filter_widget.textChanged.connect(self.onlyShowMatchedItems)
+
+        layout = QVBoxLayout()
+        layout.addWidget(self.filter_widget)
+        layout.addWidget(self.tree_widget)
+        self.setLayout(layout)
+
+    def setData(self, data: dict) -> None:
+        self.tree_widget.clear()
+        top_level_items = [_to_item(k, v) for k, v in data.items()]
+        self.tree_widget.addTopLevelItems(top_level_items)
+
+    def onlyShowMatchedItems(self, text: str) -> None:
+        matched_items = tuple(self.tree_widget.findItems(text, Qt.MatchContains | Qt.MatchRecursive))
+        for i in range(self.tree_widget.topLevelItemCount()):
+            top_level_item = self.tree_widget.topLevelItem(i)
+            _only_show_matched_items(top_level_item, matched_items)
+
+
+def _to_item(name: str, value: Any) -> QTreeWidgetItem:
+    item = QTreeWidgetItem((name, str(value)))
+    if isinstance(value, dict):
+        for k, v in value.items():
+            child = _to_item(k, v)
+            item.addChild(child)
+    elif isinstance(value, list):
+        for i, v in enumerate(value):
+            child = _to_item(str(i), v)
+            item.addChild(child)
+    return item
+
+
+def _only_show_matched_items(item: QTreeWidgetItem, matched_items: Tuple[QTreeWidgetItem, ...]) -> bool:
+    is_hidden = item not in matched_items
+    for i in range(item.childCount()):
+        child_item = item.child(i)
+        child_item.setHidden(child_item not in matched_items)
+        is_hidden = is_hidden and _only_show_matched_items(child_item, matched_items)
+    item.setHidden(is_hidden)
+    return is_hidden

--- a/src/superqt/selection/_searchable_tree_widget.py
+++ b/src/superqt/selection/_searchable_tree_widget.py
@@ -28,16 +28,15 @@ class QSearchableTreeWidget(QWidget):
     def __init__(self, parent=None):
         super().__init__(parent)
 
-        self.tree_widget = QTreeWidget()
+        self.tree_widget: QTreeWidget = QTreeWidget(self)
         self.tree_widget.setHeaderLabels(("Key", "Value"))
 
-        self.filter_widget = QLineEdit()
+        self.filter_widget: QLineEdit = QLineEdit(self)
         self.filter_widget.textChanged.connect(self._updateVisibleItems)
 
-        layout = QVBoxLayout()
+        layout = QVBoxLayout(self)
         layout.addWidget(self.filter_widget)
         layout.addWidget(self.tree_widget)
-        self.setLayout(layout)
 
     def setData(self, data: Mapping) -> None:
         """Update the mapping data shown by the tree."""

--- a/src/superqt/selection/_searchable_tree_widget.py
+++ b/src/superqt/selection/_searchable_tree_widget.py
@@ -1,7 +1,7 @@
 import logging
 from typing import Any, Iterable, Mapping
 
-from qtpy.QtCore import QRegularExpression
+from qtpy.QtCore import QRegularExpression, Qt
 from qtpy.QtWidgets import QLineEdit, QTreeWidget, QTreeWidgetItem, QVBoxLayout, QWidget
 
 
@@ -30,6 +30,7 @@ class QSearchableTreeWidget(QWidget):
 
         self.tree_widget: QTreeWidget = QTreeWidget(self)
         self.tree_widget.setHeaderLabels(("Key", "Value"))
+        self.tree_widget.setUniformRowHeights(True)
 
         self.filter_widget: QLineEdit = QLineEdit(self)
         self.filter_widget.textChanged.connect(self._updateVisibleItems)
@@ -81,7 +82,8 @@ def _make_item(*, name: str, value: Any) -> QTreeWidgetItem:
             item.addChild(child)
     else:
         item = QTreeWidgetItem([name, str(value)])
-    logging.debug("_make_item: %s, %s", item.text(0), item.text(1))
+        item.setFlags(item.flags() | Qt.ItemNeverHasChildren)
+    logging.debug("_make_item: %s, %s, %s", item.text(0), item.text(1), item.flags())
     return item
 
 

--- a/src/superqt/selection/_searchable_tree_widget.py
+++ b/src/superqt/selection/_searchable_tree_widget.py
@@ -13,19 +13,19 @@ class QSearchableTreeWidget(QWidget):
         self.tree_widget.setHeaderLabels(('Key', 'Value'))
 
         self.filter_widget = QLineEdit()
-        self.filter_widget.textChanged.connect(self.onlyShowMatchedItems)
+        self.filter_widget.textChanged.connect(self._updateVisibleItems)
 
         layout = QVBoxLayout()
         layout.addWidget(self.filter_widget)
         layout.addWidget(self.tree_widget)
         self.setLayout(layout)
 
-    def setData(self, data: dict) -> None:
+    def _setData(self, data: dict) -> None:
         self.tree_widget.clear()
         top_level_items = [_to_item(k, v) for k, v in data.items()]
         self.tree_widget.addTopLevelItems(top_level_items)
 
-    def onlyShowMatchedItems(self, text: str) -> None:
+    def _updateVisibleItems(self, text: str) -> None:
         expression = QRegularExpression(text)
         for i in range(self.tree_widget.topLevelItemCount()):
             top_level_item = self.tree_widget.topLevelItem(i)
@@ -34,7 +34,7 @@ class QSearchableTreeWidget(QWidget):
     @classmethod
     def fromDict(cls, data: dict, *, parent: QWidget = None) -> 'QSearchableTreeWidget':
         widget = cls(parent)
-        widget.setData(data)
+        widget._setData(data)
         return widget
 
 
@@ -53,6 +53,10 @@ def _to_item(name: str, value: Any) -> QTreeWidgetItem:
 
 
 def _update_visible_items(item: QTreeWidgetItem, expression: QRegularExpression) -> bool:
+    """Show an item if the text of its first column is matched by the given regular expression.
+
+    Returns True if this item and all its descendants are hidden, False otherwise.
+    """
     text = item.text(0)
     is_hidden = not expression.match(text).hasMatch()
     for i in range(item.childCount()):

--- a/src/superqt/selection/_searchable_tree_widget.py
+++ b/src/superqt/selection/_searchable_tree_widget.py
@@ -98,8 +98,7 @@ def _update_visible_items(
     Returns True if the item is visible, False otherwise.
     """
     match = ancestor_match or any(
-        expression.match(item.text(i)).hasMatch()
-        for i in range(item.columnCount())
+        expression.match(item.text(i)).hasMatch() for i in range(item.columnCount())
     )
     visible = match
     for i in range(item.childCount()):

--- a/src/superqt/selection/_searchable_tree_widget.py
+++ b/src/superqt/selection/_searchable_tree_widget.py
@@ -97,12 +97,19 @@ def _update_visible_items(
     column's text matches the expression.
     Returns True if the item is visible, False otherwise.
     """
-    match = ancestor_match or any(expression.match(item.text(i)).hasMatch() for i in range(item.columnCount()))
+    match = ancestor_match or any(
+        expression.match(item.text(i)).hasMatch()
+        for i in range(item.columnCount())
+    )
     visible = match
     for i in range(item.childCount()):
         child = item.child(i)
         descendant_visible = _update_visible_items(child, expression, match)
         visible = visible or descendant_visible
     item.setHidden(not visible)
-    logging.debug("_update_visible_items: %s, %s", tuple(item.text(i) for i in range(item.columnCount())), visible)
+    logging.debug(
+        "_update_visible_items: %s, %s",
+        tuple(item.text(i) for i in range(item.columnCount())),
+        visible,
+    )
     return visible

--- a/src/superqt/selection/_searchable_tree_widget.py
+++ b/src/superqt/selection/_searchable_tree_widget.py
@@ -90,9 +90,10 @@ def _make_item(*, name: str, value: Any) -> QTreeWidgetItem:
 def _update_visible_items(
     item: QTreeWidgetItem, expression: QRegularExpression, ancestor_match: bool = False
 ) -> bool:
-    """Recursively update the visibility of a tree item based on a expression.
+    """Recursively update the visibility of a tree item based on an expression.
 
-    An item is visible if it or any of its ancestors or descendants match the expression.
+    An item is visible if it, any of its ancestors, or any of its descendants
+    match the expression.
     The text of an item's first column is used to match the expression.
     Returns True if the item is visible, False otherwise.
     """

--- a/src/superqt/selection/_searchable_tree_widget.py
+++ b/src/superqt/selection/_searchable_tree_widget.py
@@ -33,6 +33,7 @@ class QSearchableTreeWidget(QWidget):
         self.tree.setUniformRowHeights(True)
 
         self.filter: QLineEdit = QLineEdit(self)
+        self.filter.setClearButtonEnabled(True)
         self.filter.textChanged.connect(self._updateVisibleItems)
 
         layout = QVBoxLayout(self)

--- a/src/superqt/selection/_searchable_tree_widget.py
+++ b/src/superqt/selection/_searchable_tree_widget.py
@@ -69,15 +69,18 @@ def _make_item(*, name: str, value: Any) -> QTreeWidgetItem:
     add child items and build a tree. In this case, mappings use keys
     as their names whereas other iterables use their enumerated index.
     """
-    item = QTreeWidgetItem((name, str(value)))
     if isinstance(value, Mapping):
+        item = QTreeWidgetItem([name, type(value).__name__])
         for k, v in value.items():
             child = _make_item(name=k, value=v)
             item.addChild(child)
     elif isinstance(value, Iterable) and not isinstance(value, str):
+        item = QTreeWidgetItem([name, type(value).__name__])
         for i, v in enumerate(value):
             child = _make_item(name=str(i), value=v)
             item.addChild(child)
+    else:
+        item = QTreeWidgetItem([name, str(value)])
     logging.debug("_make_item: %s, %s", item.text(0), item.text(1))
     return item
 
@@ -98,5 +101,5 @@ def _update_visible_items(
         descendants_visible = _update_visible_items(child, expression, visible)
         visible = visible or descendants_visible
     item.setHidden(not visible)
-    logging.debug("visible: %s, %s", text, visible)
+    logging.debug("_update_visible_items: %s, %s", text, visible)
     return visible

--- a/tests/test_searchable_tree.py
+++ b/tests/test_searchable_tree.py
@@ -109,14 +109,21 @@ def test_search_all_match(widget: QSearchableTreeWidget):
     assert all_items(tree) == shown_items(tree)
 
 
-def test_search_match_one(widget: QSearchableTreeWidget):
+def test_search_match_one_key(widget: QSearchableTreeWidget):
     widget.filter.setText("int")
     items = shown_items(widget.tree)
     assert len(items) == 1
     assert columns(items[0]) == ("int", "42")
 
 
-def test_search_match_many(widget: QSearchableTreeWidget):
+def test_search_match_one_value(widget: QSearchableTreeWidget):
+    widget.filter.setText("test")
+    items = shown_items(widget.tree)
+    assert len(items) == 1
+    assert columns(items[0]) == ("str", "test")
+
+
+def test_search_match_many_keys(widget: QSearchableTreeWidget):
     widget.filter.setText("n")
     items = shown_items(widget.tree)
     assert len(items) == 2

--- a/tests/test_searchable_tree.py
+++ b/tests/test_searchable_tree.py
@@ -1,0 +1,133 @@
+from typing import Any, List
+import pytest
+from qtpy.QtCore import Qt
+from qtpy.QtWidgets import QTreeWidget, QTreeWidgetItem
+from superqt import QSearchableTreeWidget
+
+
+@pytest.fixture
+def data() -> dict:
+    return {
+        'null': None,
+        'string': 'test',
+        'number': 42,
+        'array': [2, 3, 5],
+        'object': {
+            'a': 1,
+            'q': (22, 99),
+        },
+    }
+
+
+@pytest.fixture
+def widget(qtbot, data: dict) -> QSearchableTreeWidget:
+    widget = QSearchableTreeWidget.fromData(data)
+    qtbot.addWidget(widget)
+    return widget
+
+
+def assert_item_equal(item: QTreeWidgetItem, key: str, value: Any):
+    assert item.text(0) == key
+    assert item.text(1) == str(value)
+
+
+def get_all_items(tree: QTreeWidget) -> List[QTreeWidgetItem]:
+    return tree.findItems('', Qt.MatchContains | Qt.MatchRecursive)
+
+
+def test_init(qtbot):
+    widget = QSearchableTreeWidget()
+    qtbot.addWidget(widget)
+    assert widget.tree_widget.topLevelItemCount() == 0
+
+
+def test_from_data(qtbot, data: dict):
+    widget = QSearchableTreeWidget.fromData(data)
+    qtbot.addWidget(widget)
+    tree = widget.tree_widget
+
+    assert tree.topLevelItemCount() == 5
+
+    item_0 = tree.topLevelItem(0)
+    assert_item_equal(item_0, 'null', None)
+    assert item_0.childCount() == 0
+
+    item_1 = tree.topLevelItem(1)
+    assert_item_equal(item_1, 'string', 'test')
+    assert item_0.childCount() == 0
+
+    item_2 = tree.topLevelItem(2)
+    assert_item_equal(item_2, 'number', 42)
+    assert item_2.childCount() == 0
+    
+    item_3 = tree.topLevelItem(3)
+    assert_item_equal(item_3, 'array', [2, 3, 5])
+    assert item_3.childCount() == 3
+    assert_item_equal(item_3.child(0), '0', 2)
+    assert_item_equal(item_3.child(1), '1', 3)
+    assert_item_equal(item_3.child(2), '2', 5)
+
+    item_4 = tree.topLevelItem(4)
+    assert_item_equal(item_4, 'object', {'a': 1, 'q': (22, 99)})
+    assert item_4.childCount() == 2
+    assert_item_equal(item_4.child(0), 'a', 1)
+    assert_item_equal(item_4.child(1), 'q', (22, 99))
+    assert item_4.child(1).childCount() == 2
+    assert_item_equal(item_4.child(1).child(0), '0', 22)
+    assert_item_equal(item_4.child(1).child(1), '1', 99)
+
+
+def test_set_data(widget: QSearchableTreeWidget):
+    tree = widget.tree_widget
+    assert tree.topLevelItemCount() != 1
+
+    widget.setData({'test': 'reset'})
+
+    assert tree.topLevelItemCount() == 1
+    assert_item_equal(tree.topLevelItem(0), 'test', 'reset')
+
+
+def test_search_no_match(widget: QSearchableTreeWidget):
+    widget.filter_widget.setText('no match here')
+    all_items = get_all_items(widget.tree_widget)
+    shown_items = [item for item in all_items if not item.isHidden()]
+    assert len(shown_items) == 0
+
+
+def test_search_all_match(widget: QSearchableTreeWidget):
+    widget.filter_widget.setText('')
+    all_items = get_all_items(widget.tree_widget)
+    shown_items = [item for item in all_items if not item.isHidden()]
+    assert all_items == shown_items
+
+
+def test_search_match_one_top_level_key(widget: QSearchableTreeWidget):
+    widget.filter_widget.setText('number')
+    all_items = get_all_items(widget.tree_widget)
+    shown_items = [item for item in all_items if not item.isHidden()]
+    assert len(shown_items) == 1
+    assert shown_items[0].text(0) == 'number'
+
+
+def test_search_match_many_top_level_keys(widget: QSearchableTreeWidget):
+    widget.filter_widget.setText('n')
+    all_items = get_all_items(widget.tree_widget)
+    shown_items = [item for item in all_items if not item.isHidden()]
+    shown_keys = set(item.text(0) for item in shown_items)
+    assert {'null', 'string', 'number'} == shown_keys
+
+
+def test_search_match_parent_then_show_unmatched_descendants(widget: QSearchableTreeWidget):
+    widget.filter_widget.setText('array')
+    all_items = get_all_items(widget.tree_widget)
+    shown_items = [item for item in all_items if not item.isHidden()]
+    shown_keys = set(item.text(0) for item in shown_items)
+    assert {'array', '0', '1', '2'} == shown_keys
+
+
+def test_search_match_descendant_then_show_unmatched_ancestors(widget: QSearchableTreeWidget):
+    widget.filter_widget.setText('q')
+    all_items = get_all_items(widget.tree_widget)
+    shown_items = [item for item in all_items if not item.isHidden()]
+    shown_keys = set(item.text(0) for item in shown_items)
+    assert {'object', 'q', '0', '1'} == shown_keys

--- a/tests/test_searchable_tree.py
+++ b/tests/test_searchable_tree.py
@@ -43,13 +43,13 @@ def shown_items(tree: QTreeWidget) -> List[QTreeWidgetItem]:
 def test_init(qtbot: QtBot):
     widget = QSearchableTreeWidget()
     qtbot.addWidget(widget)
-    assert widget.tree_widget.topLevelItemCount() == 0
+    assert widget.tree.topLevelItemCount() == 0
 
 
 def test_from_data(qtbot: QtBot, data: dict):
     widget = QSearchableTreeWidget.fromData(data)
     qtbot.addWidget(widget)
-    tree = widget.tree_widget
+    tree = widget.tree
 
     assert tree.topLevelItemCount() == 5
 
@@ -84,7 +84,7 @@ def test_from_data(qtbot: QtBot, data: dict):
 
 
 def test_set_data(widget: QSearchableTreeWidget):
-    tree = widget.tree_widget
+    tree = widget.tree
     assert tree.topLevelItemCount() != 1
 
     widget.setData({'test': 'reset'})
@@ -94,35 +94,35 @@ def test_set_data(widget: QSearchableTreeWidget):
 
 
 def test_search_no_match(widget: QSearchableTreeWidget):
-    widget.filter_widget.setText('no match here')
-    items = shown_items(widget.tree_widget)
+    widget.filter.setText('no match here')
+    items = shown_items(widget.tree)
     assert len(items) == 0
 
 
 def test_search_all_match(widget: QSearchableTreeWidget):
-    widget.filter_widget.setText('')
-    tree = widget.tree_widget
+    widget.filter.setText('')
+    tree = widget.tree
     assert all_items(tree) == shown_items(tree)
 
 
 def test_search_match_one(widget: QSearchableTreeWidget):
-    widget.filter_widget.setText('int')
-    items = shown_items(widget.tree_widget)
+    widget.filter.setText('int')
+    items = shown_items(widget.tree)
     assert len(items) == 1
     assert columns(items[0]) == ('int', '42')
 
 
 def test_search_match_many(widget: QSearchableTreeWidget):
-    widget.filter_widget.setText('n')
-    items = shown_items(widget.tree_widget)
+    widget.filter.setText('n')
+    items = shown_items(widget.tree)
     assert len(items) == 2
     assert columns(items[0]) == ('none', 'None')
     assert columns(items[1]) == ('int', '42')
 
 
 def test_search_match_one_show_unmatched_descendants(widget: QSearchableTreeWidget):
-    widget.filter_widget.setText('list')
-    items = shown_items(widget.tree_widget)
+    widget.filter.setText('list')
+    items = shown_items(widget.tree)
     assert len(items) == 4
     assert columns(items[0]) == ('list', 'list')
     assert columns(items[1]) == ('0', '2')
@@ -131,8 +131,8 @@ def test_search_match_one_show_unmatched_descendants(widget: QSearchableTreeWidg
 
 
 def test_search_match_one_show_unmatched_ancestors(widget: QSearchableTreeWidget):
-    widget.filter_widget.setText('tuple')
-    items = shown_items(widget.tree_widget)
+    widget.filter.setText('tuple')
+    items = shown_items(widget.tree)
     assert len(items) == 4
     assert columns(items[0]) == ('dict', 'dict')
     assert columns(items[1]) == ('tuple', 'tuple')

--- a/tests/test_searchable_tree.py
+++ b/tests/test_searchable_tree.py
@@ -1,4 +1,4 @@
-from typing import Any, List
+from typing import List, Tuple
 import pytest
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QTreeWidget, QTreeWidgetItem
@@ -27,18 +27,17 @@ def widget(qtbot: QtBot, data: dict) -> QSearchableTreeWidget:
     return widget
 
 
-def assert_item_equal(item: QTreeWidgetItem, key: str, value: Any):
-    assert item.text(0) == key
-    assert item.text(1) == str(value)
+def columns(item: QTreeWidgetItem) -> Tuple[str, str]:
+    return item.text(0), item.text(1)
 
 
-def get_all_items(tree: QTreeWidget) -> List[QTreeWidgetItem]:
+def all_items(tree: QTreeWidget) -> List[QTreeWidgetItem]:
     return tree.findItems('', Qt.MatchContains | Qt.MatchRecursive)
 
 
-def get_shown_items(tree: QTreeWidget) -> List[QTreeWidgetItem]:
-    all_items = get_all_items(tree)
-    return [item for item in all_items if not item.isHidden()]
+def shown_items(tree: QTreeWidget) -> List[QTreeWidgetItem]:
+    items = all_items(tree)
+    return [item for item in items if not item.isHidden()]
 
 
 def test_init(qtbot: QtBot):
@@ -55,33 +54,33 @@ def test_from_data(qtbot: QtBot, data: dict):
     assert tree.topLevelItemCount() == 5
 
     none_item = tree.topLevelItem(0)
-    assert_item_equal(none_item, 'none', None)
+    assert columns(none_item) == ('none', 'None')
     assert none_item.childCount() == 0
 
     str_item = tree.topLevelItem(1)
-    assert_item_equal(str_item, 'str', 'test')
+    assert columns(str_item) == ('str', 'test')
     assert str_item.childCount() == 0
 
     int_item = tree.topLevelItem(2)
-    assert_item_equal(int_item, 'int', 42)
+    assert columns(int_item) == ('int', '42')
     assert int_item.childCount() == 0
     
     list_item = tree.topLevelItem(3)
-    assert_item_equal(list_item, 'list', [2, 3, 5])
+    assert columns(list_item) == ('list', 'list')
     assert list_item.childCount() == 3
-    assert_item_equal(list_item.child(0), '0', 2)
-    assert_item_equal(list_item.child(1), '1', 3)
-    assert_item_equal(list_item.child(2), '2', 5)
+    assert columns(list_item.child(0)) == ('0', '2')
+    assert columns(list_item.child(1)) == ('1', '3')
+    assert columns(list_item.child(2)) == ('2', '5')
 
     dict_item = tree.topLevelItem(4)
-    assert_item_equal(dict_item, 'dict', {'float': 0.5, 'tuple': (22, 99)})
+    assert columns(dict_item) == ('dict', 'dict')
     assert dict_item.childCount() == 2
-    assert_item_equal(dict_item.child(0), 'float', 0.5)
+    assert columns(dict_item.child(0)) == ('float', '0.5')
     tuple_item = dict_item.child(1)
-    assert_item_equal(tuple_item, 'tuple', (22, 99))
+    assert columns(tuple_item) == ('tuple', 'tuple')
     assert tuple_item.childCount() == 2
-    assert_item_equal(tuple_item.child(0), '0', 22)
-    assert_item_equal(tuple_item.child(1), '1', 99)
+    assert columns(tuple_item.child(0)) == ('0', '22')
+    assert columns(tuple_item.child(1)) == ('1', '99')
 
 
 def test_set_data(widget: QSearchableTreeWidget):
@@ -91,52 +90,51 @@ def test_set_data(widget: QSearchableTreeWidget):
     widget.setData({'test': 'reset'})
 
     assert tree.topLevelItemCount() == 1
-    assert_item_equal(tree.topLevelItem(0), 'test', 'reset')
+    assert columns(tree.topLevelItem(0)) == ('test', 'reset')
 
 
 def test_search_no_match(widget: QSearchableTreeWidget):
     widget.filter_widget.setText('no match here')
-    shown_items = get_shown_items(widget.tree_widget)
-    assert len(shown_items) == 0
+    items = shown_items(widget.tree_widget)
+    assert len(items) == 0
 
 
 def test_search_all_match(widget: QSearchableTreeWidget):
     widget.filter_widget.setText('')
-    all_items = get_all_items(widget.tree_widget)
-    shown_items = get_shown_items(widget.tree_widget)
-    assert all_items == shown_items
+    tree = widget.tree_widget
+    assert all_items(tree) == shown_items(tree)
 
 
 def test_search_match_one(widget: QSearchableTreeWidget):
     widget.filter_widget.setText('int')
-    shown_items = get_shown_items(widget.tree_widget)
-    assert len(shown_items) == 1
-    assert_item_equal(shown_items[0], 'int', 42)
+    items = shown_items(widget.tree_widget)
+    assert len(items) == 1
+    assert columns(items[0]) == ('int', '42')
 
 
 def test_search_match_many(widget: QSearchableTreeWidget):
     widget.filter_widget.setText('n')
-    shown_items = get_shown_items(widget.tree_widget)
-    assert len(shown_items) == 2
-    assert_item_equal(shown_items[0], 'none', None)
-    assert_item_equal(shown_items[1], 'int', 42)
+    items = shown_items(widget.tree_widget)
+    assert len(items) == 2
+    assert columns(items[0]) == ('none', 'None')
+    assert columns(items[1]) == ('int', '42')
 
 
 def test_search_match_one_show_unmatched_descendants(widget: QSearchableTreeWidget):
     widget.filter_widget.setText('list')
-    shown_items = get_shown_items(widget.tree_widget)
-    assert len(shown_items) == 4
-    assert_item_equal(shown_items[0], 'list', [2, 3, 5])
-    assert_item_equal(shown_items[1], '0', 2)
-    assert_item_equal(shown_items[2], '1', 3)
-    assert_item_equal(shown_items[3], '2', 5)
+    items = shown_items(widget.tree_widget)
+    assert len(items) == 4
+    assert columns(items[0]) == ('list', 'list')
+    assert columns(items[1]) == ('0', '2')
+    assert columns(items[2]) == ('1', '3')
+    assert columns(items[3]) == ('2', '5')
 
 
 def test_search_match_one_show_unmatched_ancestors(widget: QSearchableTreeWidget):
     widget.filter_widget.setText('tuple')
-    shown_items = get_shown_items(widget.tree_widget)
-    assert len(shown_items) == 4
-    assert_item_equal(shown_items[0], 'dict', {'float': 0.5, 'tuple': (22, 99)})
-    assert_item_equal(shown_items[1], 'tuple', (22, 99))
-    assert_item_equal(shown_items[2], '0', 22)
-    assert_item_equal(shown_items[3], '1', 99)
+    items = shown_items(widget.tree_widget)
+    assert len(items) == 4
+    assert columns(items[0]) == ('dict', 'dict')
+    assert columns(items[1]) == ('tuple', 'tuple')
+    assert columns(items[2]) == ('0', '22')
+    assert columns(items[3]) == ('1', '99')

--- a/tests/test_searchable_tree.py
+++ b/tests/test_searchable_tree.py
@@ -16,6 +16,7 @@ def data() -> dict:
         'dict': {
             'float': 0.5,
             'tuple': (22, 99),
+            'bool': False,
         },
     }
 
@@ -74,13 +75,14 @@ def test_from_data(qtbot: QtBot, data: dict):
 
     dict_item = tree.topLevelItem(4)
     assert columns(dict_item) == ('dict', 'dict')
-    assert dict_item.childCount() == 2
+    assert dict_item.childCount() == 3
     assert columns(dict_item.child(0)) == ('float', '0.5')
     tuple_item = dict_item.child(1)
     assert columns(tuple_item) == ('tuple', 'tuple')
     assert tuple_item.childCount() == 2
     assert columns(tuple_item.child(0)) == ('0', '22')
     assert columns(tuple_item.child(1)) == ('1', '99')
+    assert columns(dict_item.child(2)) == ('bool', 'False')
 
 
 def test_set_data(widget: QSearchableTreeWidget):

--- a/tests/test_searchable_tree.py
+++ b/tests/test_searchable_tree.py
@@ -1,22 +1,24 @@
 from typing import List, Tuple
+
 import pytest
+from pytestqt.qtbot import QtBot
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QTreeWidget, QTreeWidgetItem
-from pytestqt.qtbot import QtBot
+
 from superqt import QSearchableTreeWidget
 
 
 @pytest.fixture
 def data() -> dict:
     return {
-        'none': None,
-        'str': 'test',
-        'int': 42,
-        'list': [2, 3, 5],
-        'dict': {
-            'float': 0.5,
-            'tuple': (22, 99),
-            'bool': False,
+        "none": None,
+        "str": "test",
+        "int": 42,
+        "list": [2, 3, 5],
+        "dict": {
+            "float": 0.5,
+            "tuple": (22, 99),
+            "bool": False,
         },
     }
 
@@ -33,7 +35,7 @@ def columns(item: QTreeWidgetItem) -> Tuple[str, str]:
 
 
 def all_items(tree: QTreeWidget) -> List[QTreeWidgetItem]:
-    return tree.findItems('', Qt.MatchContains | Qt.MatchRecursive)
+    return tree.findItems("", Qt.MatchContains | Qt.MatchRecursive)
 
 
 def shown_items(tree: QTreeWidget) -> List[QTreeWidgetItem]:
@@ -55,88 +57,88 @@ def test_from_data(qtbot: QtBot, data: dict):
     assert tree.topLevelItemCount() == 5
 
     none_item = tree.topLevelItem(0)
-    assert columns(none_item) == ('none', 'None')
+    assert columns(none_item) == ("none", "None")
     assert none_item.childCount() == 0
 
     str_item = tree.topLevelItem(1)
-    assert columns(str_item) == ('str', 'test')
+    assert columns(str_item) == ("str", "test")
     assert str_item.childCount() == 0
 
     int_item = tree.topLevelItem(2)
-    assert columns(int_item) == ('int', '42')
+    assert columns(int_item) == ("int", "42")
     assert int_item.childCount() == 0
-    
+
     list_item = tree.topLevelItem(3)
-    assert columns(list_item) == ('list', 'list')
+    assert columns(list_item) == ("list", "list")
     assert list_item.childCount() == 3
-    assert columns(list_item.child(0)) == ('0', '2')
-    assert columns(list_item.child(1)) == ('1', '3')
-    assert columns(list_item.child(2)) == ('2', '5')
+    assert columns(list_item.child(0)) == ("0", "2")
+    assert columns(list_item.child(1)) == ("1", "3")
+    assert columns(list_item.child(2)) == ("2", "5")
 
     dict_item = tree.topLevelItem(4)
-    assert columns(dict_item) == ('dict', 'dict')
+    assert columns(dict_item) == ("dict", "dict")
     assert dict_item.childCount() == 3
-    assert columns(dict_item.child(0)) == ('float', '0.5')
+    assert columns(dict_item.child(0)) == ("float", "0.5")
     tuple_item = dict_item.child(1)
-    assert columns(tuple_item) == ('tuple', 'tuple')
+    assert columns(tuple_item) == ("tuple", "tuple")
     assert tuple_item.childCount() == 2
-    assert columns(tuple_item.child(0)) == ('0', '22')
-    assert columns(tuple_item.child(1)) == ('1', '99')
-    assert columns(dict_item.child(2)) == ('bool', 'False')
+    assert columns(tuple_item.child(0)) == ("0", "22")
+    assert columns(tuple_item.child(1)) == ("1", "99")
+    assert columns(dict_item.child(2)) == ("bool", "False")
 
 
 def test_set_data(widget: QSearchableTreeWidget):
     tree = widget.tree
     assert tree.topLevelItemCount() != 1
 
-    widget.setData({'test': 'reset'})
+    widget.setData({"test": "reset"})
 
     assert tree.topLevelItemCount() == 1
-    assert columns(tree.topLevelItem(0)) == ('test', 'reset')
+    assert columns(tree.topLevelItem(0)) == ("test", "reset")
 
 
 def test_search_no_match(widget: QSearchableTreeWidget):
-    widget.filter.setText('no match here')
+    widget.filter.setText("no match here")
     items = shown_items(widget.tree)
     assert len(items) == 0
 
 
 def test_search_all_match(widget: QSearchableTreeWidget):
-    widget.filter.setText('')
+    widget.filter.setText("")
     tree = widget.tree
     assert all_items(tree) == shown_items(tree)
 
 
 def test_search_match_one(widget: QSearchableTreeWidget):
-    widget.filter.setText('int')
+    widget.filter.setText("int")
     items = shown_items(widget.tree)
     assert len(items) == 1
-    assert columns(items[0]) == ('int', '42')
+    assert columns(items[0]) == ("int", "42")
 
 
 def test_search_match_many(widget: QSearchableTreeWidget):
-    widget.filter.setText('n')
+    widget.filter.setText("n")
     items = shown_items(widget.tree)
     assert len(items) == 2
-    assert columns(items[0]) == ('none', 'None')
-    assert columns(items[1]) == ('int', '42')
+    assert columns(items[0]) == ("none", "None")
+    assert columns(items[1]) == ("int", "42")
 
 
 def test_search_match_one_show_unmatched_descendants(widget: QSearchableTreeWidget):
-    widget.filter.setText('list')
+    widget.filter.setText("list")
     items = shown_items(widget.tree)
     assert len(items) == 4
-    assert columns(items[0]) == ('list', 'list')
-    assert columns(items[1]) == ('0', '2')
-    assert columns(items[2]) == ('1', '3')
-    assert columns(items[3]) == ('2', '5')
+    assert columns(items[0]) == ("list", "list")
+    assert columns(items[1]) == ("0", "2")
+    assert columns(items[2]) == ("1", "3")
+    assert columns(items[3]) == ("2", "5")
 
 
 def test_search_match_one_show_unmatched_ancestors(widget: QSearchableTreeWidget):
-    widget.filter.setText('tuple')
+    widget.filter.setText("tuple")
     items = shown_items(widget.tree)
     assert len(items) == 4
-    assert columns(items[0]) == ('dict', 'dict')
-    assert columns(items[1]) == ('tuple', 'tuple')
-    assert columns(items[2]) == ('0', '22')
-    assert columns(items[3]) == ('1', '99')
+    assert columns(items[0]) == ("dict", "dict")
+    assert columns(items[1]) == ("tuple", "tuple")
+    assert columns(items[2]) == ("0", "22")
+    assert columns(items[3]) == ("1", "99")

--- a/tests/test_searchable_tree.py
+++ b/tests/test_searchable_tree.py
@@ -9,13 +9,13 @@ from superqt import QSearchableTreeWidget
 @pytest.fixture
 def data() -> dict:
     return {
-        'null': None,
-        'string': 'test',
-        'number': 42,
-        'array': [2, 3, 5],
-        'object': {
-            'a': 1,
-            'q': (22, 99),
+        'none': None,
+        'str': 'test',
+        'int': 42,
+        'list': [2, 3, 5],
+        'dict': {
+            'float': 0.5,
+            'tuple': (22, 99),
         },
     }
 
@@ -54,31 +54,31 @@ def test_from_data(qtbot: QtBot, data: dict):
 
     assert tree.topLevelItemCount() == 5
 
-    null_item = tree.topLevelItem(0)
-    assert_item_equal(null_item, 'null', None)
-    assert null_item.childCount() == 0
+    none_item = tree.topLevelItem(0)
+    assert_item_equal(none_item, 'none', None)
+    assert none_item.childCount() == 0
 
-    string_item = tree.topLevelItem(1)
-    assert_item_equal(string_item, 'string', 'test')
-    assert string_item.childCount() == 0
+    str_item = tree.topLevelItem(1)
+    assert_item_equal(str_item, 'str', 'test')
+    assert str_item.childCount() == 0
 
-    number_item = tree.topLevelItem(2)
-    assert_item_equal(number_item, 'number', 42)
-    assert number_item.childCount() == 0
+    int_item = tree.topLevelItem(2)
+    assert_item_equal(int_item, 'int', 42)
+    assert int_item.childCount() == 0
     
-    array_item = tree.topLevelItem(3)
-    assert_item_equal(array_item, 'array', [2, 3, 5])
-    assert array_item.childCount() == 3
-    assert_item_equal(array_item.child(0), '0', 2)
-    assert_item_equal(array_item.child(1), '1', 3)
-    assert_item_equal(array_item.child(2), '2', 5)
+    list_item = tree.topLevelItem(3)
+    assert_item_equal(list_item, 'list', [2, 3, 5])
+    assert list_item.childCount() == 3
+    assert_item_equal(list_item.child(0), '0', 2)
+    assert_item_equal(list_item.child(1), '1', 3)
+    assert_item_equal(list_item.child(2), '2', 5)
 
-    object_item = tree.topLevelItem(4)
-    assert_item_equal(object_item, 'object', {'a': 1, 'q': (22, 99)})
-    assert object_item.childCount() == 2
-    assert_item_equal(object_item.child(0), 'a', 1)
-    tuple_item = object_item.child(1)
-    assert_item_equal(tuple_item, 'q', (22, 99))
+    dict_item = tree.topLevelItem(4)
+    assert_item_equal(dict_item, 'dict', {'float': 0.5, 'tuple': (22, 99)})
+    assert dict_item.childCount() == 2
+    assert_item_equal(dict_item.child(0), 'float', 0.5)
+    tuple_item = dict_item.child(1)
+    assert_item_equal(tuple_item, 'tuple', (22, 99))
     assert tuple_item.childCount() == 2
     assert_item_equal(tuple_item.child(0), '0', 22)
     assert_item_equal(tuple_item.child(1), '1', 99)
@@ -108,36 +108,35 @@ def test_search_all_match(widget: QSearchableTreeWidget):
 
 
 def test_search_match_one(widget: QSearchableTreeWidget):
-    widget.filter_widget.setText('number')
+    widget.filter_widget.setText('int')
     shown_items = get_shown_items(widget.tree_widget)
     assert len(shown_items) == 1
-    assert_item_equal(shown_items[0], 'number', 42)
+    assert_item_equal(shown_items[0], 'int', 42)
 
 
 def test_search_match_many(widget: QSearchableTreeWidget):
     widget.filter_widget.setText('n')
     shown_items = get_shown_items(widget.tree_widget)
-    assert len(shown_items) == 3
-    assert_item_equal(shown_items[0], 'null', None)
-    assert_item_equal(shown_items[1], 'string', 'test')
-    assert_item_equal(shown_items[2], 'number', 42)
+    assert len(shown_items) == 2
+    assert_item_equal(shown_items[0], 'none', None)
+    assert_item_equal(shown_items[1], 'int', 42)
 
 
 def test_search_match_one_show_unmatched_descendants(widget: QSearchableTreeWidget):
-    widget.filter_widget.setText('array')
+    widget.filter_widget.setText('list')
     shown_items = get_shown_items(widget.tree_widget)
     assert len(shown_items) == 4
-    assert_item_equal(shown_items[0], 'array', [2, 3, 5])
+    assert_item_equal(shown_items[0], 'list', [2, 3, 5])
     assert_item_equal(shown_items[1], '0', 2)
     assert_item_equal(shown_items[2], '1', 3)
     assert_item_equal(shown_items[3], '2', 5)
 
 
 def test_search_match_one_show_unmatched_ancestors(widget: QSearchableTreeWidget):
-    widget.filter_widget.setText('q')
+    widget.filter_widget.setText('tuple')
     shown_items = get_shown_items(widget.tree_widget)
     assert len(shown_items) == 4
-    assert_item_equal(shown_items[0], 'object', {'a': 1, 'q': (22, 99)})
-    assert_item_equal(shown_items[1], 'q', (22, 99))
+    assert_item_equal(shown_items[0], 'dict', {'float': 0.5, 'tuple': (22, 99)})
+    assert_item_equal(shown_items[1], 'tuple', (22, 99))
     assert_item_equal(shown_items[2], '0', 22)
     assert_item_equal(shown_items[3], '1', 99)


### PR DESCRIPTION
This adds a searchable tree widget that can be initialized from a mapping. Mappings and iterables (other than strings) are traversed and populated in the tree. The tree has two columns.

The first column is either the key of a mapping or the enumerated index of an iterable, which can be searched based on regular expression. An item is shown if it, any of its ancestors, or any of its descendants match the expression. Ancestors are needed because tree items are only shown if all their ancestors are. Descendants are needed because if the user if look for a key that 

The second column is either the `str()` value (for terminal types) or the type itself (e.g. `dict`) for non-terminal iterables.

I think this closes #12 , though I have not tried to reimplement [OMETree](https://github.com/tlambert03/ome-types/blob/9954ae63c162ce91d516167009590bcc20a77174/src/ome_types/widgets.py#L21) using this yet.

Here's an example of using the tree on [an OME-NGFF `multiscales` group `.zattrs` JSON file from Zenodo](https://zenodo.org/record/7120354#.ZD3OjezML0o), which is easy to setup with just a `json.load`.

https://user-images.githubusercontent.com/2608297/232627769-9c74592d-8a4c-4d9f-af0c-e545e75e87b5.mp4

For XML, one would have to convert the element tree into a dictionary first (e.g. using [`xmltodict`].(https://github.com/martinblech/xmltodict)).