### PR TITLE
[WIP] Simplify mouse drag simulation

### DIFF
--- a/tests/test_sliders/test_slider.py
+++ b/tests/test_sliders/test_slider.py
@@ -56,10 +56,9 @@ def test_drag_handles(qtbot):
     assert rs._pressedIndex == 0
 
     # drag the left handle
-    with qtbot.waitSignals([rs.sliderMoved] * 13):  # couple less signals
-        for _ in range(15):
-            pos.setX(pos.x() + 2)
-            qtbot.mouseMove(rs, pos)
+    pos.setX(pos.x() + 30)
+    with qtbot.waitSignal(rs.sliderMoved):
+        qtbot.mouseMove(rs, pos)
 
     with qtbot.waitSignal(rs.sliderReleased):
         qtbot.mouseRelease(rs, Qt.MouseButton.LeftButton)
@@ -76,10 +75,10 @@ def test_drag_handles(qtbot):
     assert rs._pressedIndex == 1
 
     # drag the right handle
-    with qtbot.waitSignals([rs.sliderMoved] * 13):  # couple less signals
-        for _ in range(15):
-            pos.setX(pos.x() - 2)
-            qtbot.mouseMove(rs, pos)
+    with qtbot.waitSignal(rs.sliderMoved):
+        pos.setX(pos.x() - 30)
+        qtbot.mouseMove(rs, pos)
+
     with qtbot.waitSignal(rs.sliderReleased):
         qtbot.mouseRelease(rs, Qt.MouseButton.LeftButton)
 
@@ -105,8 +104,8 @@ def test_drag_handles_beyond_edge(qtbot):
     assert rs._pressedIndex == 1
 
     # drag the handle off the right edge and make sure the value gets to the max
-    for _ in range(7):
-        pos.setX(pos.x() + 10)
+    with qtbot.waitSignal(rs.sliderMoved):
+        pos.setX(pos.x() + 70)
         qtbot.mouseMove(rs, pos)
 
     with qtbot.waitSignal(rs.sliderReleased):
@@ -132,8 +131,8 @@ def test_bar_drag_beyond_edge(qtbot):
     assert rs._pressedIndex == 1
 
     # drag the handle off the right edge and make sure the value gets to the max
-    for _ in range(15):
-        pos.setX(pos.x() + 10)
+    with qtbot.waitSignal(rs.sliderMoved):
+        pos.setX(pos.x() + 150)
         qtbot.mouseMove(rs, pos)
 
     with qtbot.waitSignal(rs.sliderReleased):


### PR DESCRIPTION
Seems like the tests here can all be a bit flaky: https://github.com/pyapp-kit/superqt/actions/runs/4759738566/jobs/8459314640#step:8:510

It's not immediately obvious to me what the need for simulated fine-grained movements is in these tests, so I just made a single big move instead. Feel free to let me know if I'm missing an important detail here. Alternatively, we could use `waitSignal` within the for loop if each call is needed.

I'm still not entirely sure about the internals of qtbot and QTest (e.g. in particular where/what is the main event loop and what guarantees are made about processing events).