### PR TITLE
Set parent of timer in throttler

### DIFF
--- a/src/superqt/utils/_throttler.py
+++ b/src/superqt/utils/_throttler.py
@@ -78,7 +78,7 @@ class GenericSignalThrottler(QObject):
         self._emissionPolicy = emissionPolicy
         self._hasPendingEmission = False
 
-        self._timer = QTimer()
+        self._timer = QTimer(parent=self)
         self._timer.setSingleShot(True)
         self._timer.setTimerType(Qt.TimerType.PreciseTimer)
         self._timer.timeout.connect(self._maybeEmitTriggered)


### PR DESCRIPTION
Lack of a set timer paren may delay timer deletion. It may create some of the observed problems with hanging timers. I'm not 100% sure, but adding this parent covers with general Qt memory model. 