### PR TITLE
[proof of concept] make labelled range sliders expandable by modifying label range

### DIFF
--- a/src/superqt/sliders/_labeled.py
+++ b/src/superqt/sliders/_labeled.py
@@ -150,6 +150,9 @@ class QLabeledSlider(_SliderProxy, QAbstractSlider):
 
     def _setValue(self, value: float):
         """Convert the value from float to int before setting the slider value."""
+        value = int(value)
+        if self._slider.maximum() < value:
+            self._slider.setMaximum(value)
         self._slider.setValue(int(value))
 
     def _rename_signals(self):

--- a/src/superqt/sliders/_labeled.py
+++ b/src/superqt/sliders/_labeled.py
@@ -432,9 +432,9 @@ class QLabeledRangeSlider(_SliderProxy, QAbstractSlider):
             self._max_label.setValue(max)
         self._reposition_labels()
 
-    def setValue(self, value) -> None:
-        super().setValue(value)
-        self.sliderChange(QSlider.SliderValueChange)
+    # def setValue(self, value) -> None:
+    #     super().setValue(value)
+    #     self.sliderChange(QSlider.SliderValueChange)
 
     def setRange(self, min, max) -> None:
         self._on_range_changed(min, max)

--- a/src/superqt/sliders/_labeled.py
+++ b/src/superqt/sliders/_labeled.py
@@ -153,6 +153,8 @@ class QLabeledSlider(_SliderProxy, QAbstractSlider):
         value = int(value)
         if self._slider.maximum() < value:
             self._slider.setMaximum(value)
+        elif self._slider.minimum() > value:
+            self._slider.setMinimum(value)
         self._slider.setValue(int(value))
 
     def _rename_signals(self):


### PR DESCRIPTION
Hey Talley, I wanted a labelled QSlider where the label could be used to update the slider range like your labelled double slider. This PR is a minimal change that allows this to work for QLabeledSlider if the label range is manually updated

I've opened this PR so that we can discuss if there might be a better approach/worth adding some convenience for on the labelled slider class. If you think this is okay as-is then I'll add some tests before merge

```python
from qtpy.QtCore import Qt
from qtpy.QtWidgets import QApplication, QVBoxLayout, QWidget

from superqt import QLabeledSlider

app = QApplication([])

ORIENTATION = Qt.Orientation.Horizontal

w = QWidget()
w.setLayout(QVBoxLayout())

qls = QLabeledSlider(ORIENTATION)
qls.valueChanged.connect(lambda e: print("qls valueChanged", e))
qls.setRange(0, 100)
qls.setValue(30)

# update the label range - comment this line to revert to default behaviour
qls._label.setRange(0, 1000)

w.layout().addWidget(qls)

w.show()
app.exec_()
```

behaviour without this change (value can't be set outside of slider range (0, 100)):

https://github.com/pyapp-kit/superqt/assets/7307488/2bcc94f8-dc1f-4a89-9f31-9f901f04b8b3

behaviour with this change (range can be extended (value can be set to any value in label range (0, 1000), slider updates):

https://github.com/pyapp-kit/superqt/assets/7307488/e8cacde2-8aff-4ccf-b6d0-d4ba49c39caf

