### PR TITLE
build: unpin pyside6.5

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -32,16 +32,16 @@ jobs:
         include:
           - python-version: "3.10"
             platform: macos-latest
-            backend: pyside6==6.5.0
+            backend: pyside6
           - python-version: "3.11"
             platform: macos-latest
-            backend: pyside6==6.5.0
+            backend: pyside6
           - python-version: "3.10"
             platform: windows-latest
-            backend: pyside6==6.5.0
+            backend: pyside6
           - python-version: "3.11"
             platform: windows-latest
-            backend: pyside6==6.5.0
+            backend: pyside6
 
           # python 3.7
           - python-version: 3.7

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dev = [
 docs = ["mkdocs-macros-plugin", "mkdocs-material", "mkdocstrings[python]"]
 quantity = ["pint"]
 pyside2 = ["pyside2"]
-pyside6 = ["pyside6<6.5.1"]
+pyside6 = ["pyside6 !=6.5.0,!=6.5.1"]
 pyqt5 = ["pyqt5"]
 pyqt6 = ["pyqt6"]
 font-fa5 = ["fonticon-fontawesome5"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,9 @@ dev = [
 docs = ["mkdocs-macros-plugin", "mkdocs-material", "mkdocstrings[python]"]
 quantity = ["pint"]
 pyside2 = ["pyside2"]
+# see issues surrounding usage of Generics in pyside6.5.x
+# https://github.com/pyapp-kit/superqt/pull/177
+# https://github.com/pyapp-kit/superqt/pull/164
 pyside6 = ["pyside6 !=6.5.0,!=6.5.1"]
 pyqt5 = ["pyqt5"]
 pyqt6 = ["pyqt6"]


### PR DESCRIPTION
looks like pyside 6.5.2 has fixed a lot of the issues with subclassing `Generic`.  haven't looked for/found the upstream Qt issue yet, but many things now work in local testing.  This PR unpins our pyside6 extra, and updates the test suite again