### PR TITLE
fix: fix parameter inspection on ensure_thread decorators

### DIFF
--- a/tests/test_ensure_thread.py
+++ b/tests/test_ensure_thread.py
@@ -52,7 +52,6 @@ class SampleObject(QObject):
     def check_main_thread(self, a, *, b=1):
         if QThread.currentThread() is not QCoreApplication.instance().thread():
             raise RuntimeError("Wrong thread")
-
         self.main_thread_res = {"a": a, "b": b}
         self.assigment_done.emit()
 

--- a/tests/test_ensure_thread.py
+++ b/tests/test_ensure_thread.py
@@ -233,4 +233,9 @@ def test_ensure_thread_sig_inspection(deco):
     obj = Emitter()
     r = Receiver()
     obj.sig.connect(r.func)
+
+    # this is the crux of the test...
+    # we emit 3 args, but the function only takes 2
+    # this should normally work fine in Qt.
+    # testing here that the decorator doesn't break it.
     obj.sig.emit(1, 2, 3)


### PR DESCRIPTION
fixes #182  ... and adds a test, but it sure isn't pretty at the moment :joy:

@Czaki, I'll keep playing with this (and digging into the qt source code) to see if I can come up with a more elegant way for Qt to be able to properly inspect the signature of a decorated wrapped function.  but if you have any other ideas i should try, feel free to propose!

**edit**
see also #185, which I think prefer now