### PR TITLE
Implement throttling of methods

### DIFF
--- a/src/superqt/utils/_throttler.py
+++ b/src/superqt/utils/_throttler.py
@@ -207,7 +207,6 @@ class ThrottledCallable(GenericSignalThrottler, Generic[P, R]):
         self._args: tuple = ()
         self._kwargs: dict = {}
         self.triggered.connect(self._set_future_result)
-        self._name = None
 
         # even if we were to compile __call__ with a signature matching that of func,
         # PySide wouldn't correctly inspect the signature of the ThrottledCallable
@@ -234,11 +233,21 @@ class ThrottledCallable(GenericSignalThrottler, Generic[P, R]):
         result = self.__wrapped__(*self._args[: self._max_args], **self._kwargs)
         self._future.set_result(result)
 
+
+class ThrottledCallableDescriptor(ThrottledCallable):
+    def __init__(
+        self,
+        func: Callable[P, R],
+        kind: Kind,
+        emissionPolicy: EmissionPolicy,
+        parent: QObject | None = None,
+    ) -> None:
+        super().__init__(func, kind, emissionPolicy, parent)
+        self._name = None
+
     def __set_name__(self, owner, name):
         self._name = name
 
-
-class ThrottledCallableDescriptor(ThrottledCallable):
     def __get__(self, instance, owner):
         parent = self.parent()
         if isinstance(self.__wrapped__, staticmethod):

--- a/src/superqt/utils/_throttler.py
+++ b/src/superqt/utils/_throttler.py
@@ -213,7 +213,6 @@ class ThrottledCallable(GenericSignalThrottler, Generic[P, R]):
         self._kwargs: dict = {}
         self.triggered.connect(self._set_future_result)
         self._name = None
-        self._is_static = isinstance(func, staticmethod)
 
         # even if we were to compile __call__ with a signature matching that of func,
         # PySide wouldn't correctly inspect the signature of the ThrottledCallable
@@ -238,10 +237,8 @@ class ThrottledCallable(GenericSignalThrottler, Generic[P, R]):
         self._future.set_result(result)
 
     def __set_name__(self, owner, name):
-        if not self._is_static:
+        if not isinstance(self.__wrapped__, staticmethod):
             self._name = name
-        if isinstance(self.__wrapped__, staticmethod):
-            self.__wrapped__ = self.__wrapped__.__func__
 
     def _get_throttler(self, instance, owner, parent, obj):
         throttler = ThrottledCallable(

--- a/src/superqt/utils/_throttler.py
+++ b/src/superqt/utils/_throttler.py
@@ -242,7 +242,7 @@ class ThrottledCallable(GenericSignalThrottler, Generic[P, R]):
         self._name = name
 
     def __get__(self, instance, owner):
-        if instance is None:
+        if instance is None or not self._name:
             return self
         parent = self.parent()
         if parent is None and isinstance(instance, QObject):

--- a/src/superqt/utils/_throttler.py
+++ b/src/superqt/utils/_throttler.py
@@ -232,7 +232,7 @@ class ThrottledCallable(GenericSignalThrottler, Generic[P, R]):
     def _set_future_result(self):
         if self._instance is not None:
             result = self.__wrapped__(
-                self._instance, *self._args[: self._max_args], **self._kwargs
+                self._instance, *self._args[: self._max_args - 1], **self._kwargs
             )
         else:
             result = self.__wrapped__(*self._args[: self._max_args], **self._kwargs)

--- a/src/superqt/utils/_throttler.py
+++ b/src/superqt/utils/_throttler.py
@@ -320,7 +320,8 @@ def qthrottled(
               desired interval
             - `Qt.VeryCoarseTimer`: Very coarse timers only keep full second accuracy
     parent: QObject or None
-        Parent object for timer. If using qthrottled as function it may be usefull for cleaning data
+        Parent object for timer. If using qthrottled as function it may be usefull
+        for cleaning data
     """
     return _make_decorator(func, timeout, leading, timer_type, Kind.Throttler, parent)
 
@@ -385,7 +386,8 @@ def qdebounced(
               desired interval
             - `Qt.VeryCoarseTimer`: Very coarse timers only keep full second accuracy
     parent: QObject or None
-        Parent object for timer. If using qthrottled as function it may be usefull for cleaning data
+        Parent object for timer. If using qthrottled as function it may be usefull
+        for cleaning data
     """
     return _make_decorator(func, timeout, leading, timer_type, Kind.Debouncer, parent)
 

--- a/src/superqt/utils/_throttler.py
+++ b/src/superqt/utils/_throttler.py
@@ -403,8 +403,8 @@ def _make_decorator(
     def deco(func: Callable[P, R]) -> ThrottledCallable[P, R]:
         nonlocal parent
 
-        instance: QObject | None = getattr(func, "__self__", None)
-        if instance is not None and parent is None:
+        instance: object | None = getattr(func, "__self__", None)
+        if isinstance(instance, QObject) and parent is None:
             parent = instance
         policy = EmissionPolicy.Leading if leading else EmissionPolicy.Trailing
         obj = ThrottledCallable(func, kind, policy, parent=parent)

--- a/src/superqt/utils/_throttler.py
+++ b/src/superqt/utils/_throttler.py
@@ -242,7 +242,11 @@ class ThrottledCallable(GenericSignalThrottler, Generic[P, R]):
         self._name = name
 
     def __get__(self, instance, owner):
-        if instance is None or not self._name:
+        if (
+            instance is None
+            or not self._name
+            or isinstance(self.__wrapped__, staticmethod)
+        ):
             return self
         parent = self.parent()
         if parent is None and isinstance(instance, QObject):

--- a/src/superqt/utils/_throttler.py
+++ b/src/superqt/utils/_throttler.py
@@ -32,7 +32,6 @@ from concurrent.futures import Future
 from enum import IntFlag, auto
 from functools import wraps
 from typing import TYPE_CHECKING, Callable, Generic, TypeVar, overload
-from inspect import ismethod
 
 from qtpy.QtCore import QObject, Qt, QTimer, Signal
 
@@ -199,7 +198,7 @@ class ThrottledCallable(GenericSignalThrottler, Generic[P, R]):
         kind: Kind,
         emissionPolicy: EmissionPolicy,
         parent: QObject | None = None,
-        instance: object | None = None
+        instance: object | None = None,
     ) -> None:
         super().__init__(kind, emissionPolicy, parent)
 
@@ -232,7 +231,9 @@ class ThrottledCallable(GenericSignalThrottler, Generic[P, R]):
 
     def _set_future_result(self):
         if self._instance is not None:
-            result = self.__wrapped__(self._instance, *self._args[: self._max_args], **self._kwargs)
+            result = self.__wrapped__(
+                self._instance, *self._args[: self._max_args], **self._kwargs
+            )
         else:
             result = self.__wrapped__(*self._args[: self._max_args], **self._kwargs)
         self._future.set_result(result)
@@ -247,16 +248,19 @@ class ThrottledCallable(GenericSignalThrottler, Generic[P, R]):
         if parent is None and isinstance(instance, QObject):
             parent = instance
 
-        setattr(instance, self._name, ThrottledCallable(
-            func=self.__wrapped__,
-            kind=self._kind,
-            emissionPolicy=self._emissionPolicy,
-            parent=parent,
-            instance=instance
-        ))
+        setattr(
+            instance,
+            self._name,
+            ThrottledCallable(
+                func=self.__wrapped__,
+                kind=self._kind,
+                emissionPolicy=self._emissionPolicy,
+                parent=parent,
+                instance=instance,
+            ),
+        )
 
         return getattr(instance, self._name)
-
 
 
 @overload
@@ -265,7 +269,7 @@ def qthrottled(
     timeout: int = 100,
     leading: bool = True,
     timer_type: Qt.TimerType = Qt.TimerType.PreciseTimer,
-    parent: QObject | None = None
+    parent: QObject | None = None,
 ) -> ThrottledCallable[P, R]:
     ...
 
@@ -276,7 +280,7 @@ def qthrottled(
     timeout: int = 100,
     leading: bool = True,
     timer_type: Qt.TimerType = Qt.TimerType.PreciseTimer,
-    parent: QObject | None = None
+    parent: QObject | None = None,
 ) -> Callable[[Callable[P, R]], ThrottledCallable[P, R]]:
     ...
 
@@ -286,7 +290,7 @@ def qthrottled(
     timeout: int = 100,
     leading: bool = True,
     timer_type: Qt.TimerType = Qt.TimerType.PreciseTimer,
-    parent: QObject | None = None
+    parent: QObject | None = None,
 ) -> ThrottledCallable[P, R] | Callable[[Callable[P, R]], ThrottledCallable[P, R]]:
     """Creates a throttled function that invokes func at most once per timeout.
 
@@ -327,7 +331,7 @@ def qdebounced(
     timeout: int = 100,
     leading: bool = False,
     timer_type: Qt.TimerType = Qt.TimerType.PreciseTimer,
-    parent: QObject | None = None
+    parent: QObject | None = None,
 ) -> ThrottledCallable[P, R]:
     ...
 
@@ -338,7 +342,7 @@ def qdebounced(
     timeout: int = 100,
     leading: bool = False,
     timer_type: Qt.TimerType = Qt.TimerType.PreciseTimer,
-    parent: QObject | None = None
+    parent: QObject | None = None,
 ) -> Callable[[Callable[P, R]], ThrottledCallable[P, R]]:
     ...
 
@@ -348,7 +352,7 @@ def qdebounced(
     timeout: int = 100,
     leading: bool = False,
     timer_type: Qt.TimerType = Qt.TimerType.PreciseTimer,
-    parent: QObject | None = None
+    parent: QObject | None = None,
 ) -> ThrottledCallable[P, R] | Callable[[Callable[P, R]], ThrottledCallable[P, R]]:
     """Creates a debounced function that delays invoking `func`.
 
@@ -392,9 +396,8 @@ def _make_decorator(
     leading: bool,
     timer_type: Qt.TimerType,
     kind: Kind,
-    parent: QObject | None = None
+    parent: QObject | None = None,
 ) -> ThrottledCallable[P, R] | Callable[[Callable[P, R]], ThrottledCallable[P, R]]:
-
     def deco(func: Callable[P, R]) -> ThrottledCallable[P, R]:
         nonlocal parent
 

--- a/tests/test_throttler.py
+++ b/tests/test_throttler.py
@@ -83,7 +83,7 @@ def test_debouncer_method_definition(qtbot):
     qtbot.wait(5)
 
     assert a.count == 1
-    assert mock1.call_count == 2
+    mock1.assert_called_once()
     mock2.assert_called_once()
 
 

--- a/tests/test_throttler.py
+++ b/tests/test_throttler.py
@@ -61,7 +61,7 @@ def test_debouncer_method_definition(qtbot):
     a = A()
     assert all(not isinstance(x, ThrottledCallable) for x in a.children())
     for _ in range(10):
-        a.callback()
+        a.callback(1)
 
     qtbot.wait(5)
 

--- a/tests/test_throttler.py
+++ b/tests/test_throttler.py
@@ -50,6 +50,7 @@ def test_debouncer_method(qtbot):
 
 def test_debouncer_method_definition(qtbot):
     mock1 = Mock()
+    mock2 = Mock()
 
     class A(QObject):
         def __init__(self):
@@ -62,19 +63,28 @@ def test_debouncer_method_definition(qtbot):
 
         @qdebounced(timeout=4)
         @staticmethod
-        def call():
+        def call1():
             mock1()
+
+        @staticmethod
+        @qdebounced(timeout=4)
+        def call2():
+            mock2()
 
     a = A()
     assert all(not isinstance(x, ThrottledCallable) for x in a.children())
     for _ in range(10):
         a.callback(1)
-        a.call(22)
+        A.call1(34)
+        a.call1(22)
+        a.call2(22)
+        A.call2(32)
 
     qtbot.wait(5)
 
     assert a.count == 1
-    mock1.assert_called_once()
+    assert mock1.call_count == 2
+    mock2.assert_called_once()
 
 
 def test_throttled(qtbot):

--- a/tests/test_throttler.py
+++ b/tests/test_throttler.py
@@ -4,7 +4,6 @@ import pytest
 from qtpy.QtCore import QObject, Signal
 
 from superqt.utils import qdebounced, qthrottled
-
 from superqt.utils._throttler import ThrottledCallable
 
 
@@ -29,7 +28,6 @@ def test_debounced(qtbot):
 
 
 def test_debouncer_method(qtbot):
-
     class A(QObject):
         def __init__(self):
             super().__init__()
@@ -51,7 +49,6 @@ def test_debouncer_method(qtbot):
 
 
 def test_debouncer_method_definition(qtbot):
-
     class A(QObject):
         def __init__(self):
             super().__init__()
@@ -69,6 +66,7 @@ def test_debouncer_method_definition(qtbot):
     qtbot.wait(5)
 
     assert a.count == 1
+
 
 def test_throttled(qtbot):
     mock1 = Mock()

--- a/tests/test_throttler.py
+++ b/tests/test_throttler.py
@@ -49,6 +49,8 @@ def test_debouncer_method(qtbot):
 
 
 def test_debouncer_method_definition(qtbot):
+    mock1 = Mock()
+
     class A(QObject):
         def __init__(self):
             super().__init__()
@@ -58,14 +60,21 @@ def test_debouncer_method_definition(qtbot):
         def callback(self):
             self.count += 1
 
+        @qdebounced(timeout=4)
+        @staticmethod
+        def call():
+            mock1()
+
     a = A()
     assert all(not isinstance(x, ThrottledCallable) for x in a.children())
     for _ in range(10):
         a.callback(1)
+        a.call(22)
 
     qtbot.wait(5)
 
     assert a.count == 1
+    mock1.assert_called_once()
 
 
 def test_throttled(qtbot):


### PR DESCRIPTION
Allow to use `qdebounced` and `qthrottled` on methods with proper setting parent if use Qt objects. 