### PR TITLE
fix: remove dupes/aliases in QEnumCombo

### DIFF
--- a/src/superqt/combobox/_enum_combobox.py
+++ b/src/superqt/combobox/_enum_combobox.py
@@ -49,7 +49,9 @@ class QEnumComboBox(QComboBox):
         self._allow_none = allow_none and enum is not None
         if allow_none:
             super().addItem(NONE_STRING)
-        super().addItems(list(map(_get_name, self._enum_class.__members__.values())))
+        names = map(_get_name, self._enum_class.__members__.values())
+        _names = dict.fromkeys(names)  # remove duplicates/aliases, keep order
+        super().addItems(list(_names))
 
     def enumClass(self) -> Optional[EnumMeta]:
         """Return current Enum class."""

--- a/tests/test_enum_comb_box.py
+++ b/tests/test_enum_comb_box.py
@@ -11,6 +11,8 @@ class Enum1(Enum):
     b = 2
     c = 3
 
+    ALIAS = a
+
 
 class Enum2(Enum):
     d = 1


### PR DESCRIPTION
This PR removes duplicates/aliases from showing up in a QEnumCombo:

```
class MyEnum(Enum):
    VALUE = 'value'
    ALIAS = VALUE
```

should only show 'value' once, not twice