### PR TITLE
feat: add error `exceptions_as_dialog` context manager to catch and show Exceptions

### DIFF
--- a/docs/utilities/error_dialog_contexts.md
+++ b/docs/utilities/error_dialog_contexts.md
@@ -1,0 +1,3 @@
+# Error message context manager
+
+::: superqt.utils.exceptions_as_dialog

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,7 @@ theme:
     # - navigation.tabs
     - search.highlight
     - search.suggest
+    - content.code.copy
 
 markdown_extensions:
   - admonition

--- a/src/superqt/utils/__init__.py
+++ b/src/superqt/utils/__init__.py
@@ -14,10 +14,12 @@ __all__ = (
     "signals_blocked",
     "thread_worker",
     "WorkerBase",
+    "exceptions_as_dialog",
 )
 
 from ._code_syntax_highlight import CodeSyntaxHighlight
 from ._ensure_thread import ensure_main_thread, ensure_object_thread
+from ._errormsg_context import exceptions_as_dialog
 from ._message_handler import QMessageHandler
 from ._misc import signals_blocked
 from ._qthreading import (

--- a/src/superqt/utils/_errormsg_context.py
+++ b/src/superqt/utils/_errormsg_context.py
@@ -29,9 +29,11 @@ class exceptions_as_dialog(AbstractContextManager):
     msg_template : str, optional
         The message to show in the `QMessageBox`. The message will be formatted
         using three variables:
+
         - `exc_value`: the exception instance
         - `exc_type`: the exception type
         - `tb`: the traceback as a string
+
         The default template is the content of the exception: `"{exc_value}"`
     buttons : QMessageBox.StandardButton, optional
         The buttons to show in the `QMessageBox`, by default

--- a/src/superqt/utils/_errormsg_context.py
+++ b/src/superqt/utils/_errormsg_context.py
@@ -1,0 +1,85 @@
+import traceback
+from contextlib import AbstractContextManager
+from types import TracebackType
+
+from qtpy.QtWidgets import QErrorMessage, QMessageBox, QWidget
+
+_GLOBAL_ERR = None
+
+
+def global_err_message() -> QErrorMessage:
+    global _GLOBAL_ERR
+    if _GLOBAL_ERR is None:
+        _GLOBAL_ERR = QErrorMessage()
+    return _GLOBAL_ERR
+
+
+class exceptions_as_dialog(AbstractContextManager):
+    """Context manager that shows a QMessageBox when an exception is raised.
+
+    Example
+    -------
+    ```python
+    with exceptions_as_dialog():
+        raise Exception("This will be caught and shown in a QMessageBox")
+
+    with exceptions_as_dialog(ValueError):
+        1 / 0  # ZeroDivisionError is not caught, so this will raise
+
+    with exceptions_as_dialog(msg_template="Error: {exc_value}"):
+        raise Exception("This message will be used as 'exc_value'")
+
+    for _i in range(3):
+        with exceptions_as_dialog(AssertionError, global_err_message=True):
+            assert False, "Uncheck the checkbox to ignore this in the future"
+    ```
+    """
+
+    widget: QMessageBox | None
+    raised: bool
+
+    def __init__(
+        self,
+        exceptions: type[BaseException] | tuple[type[BaseException], ...] = (Exception),
+        icon: QMessageBox.Icon = QMessageBox.Icon.Critical,
+        title: str = "An error occurred",
+        msg_template: str = "{exc_value}",
+        buttons: QMessageBox.StandardButton = QMessageBox.StandardButton.Ok,
+        parent: QWidget | None = None,
+        use_global_err_message: bool = False,
+    ):
+        self.exceptions = exceptions
+        self.msg_template = msg_template
+        self.use_global_err_message = use_global_err_message
+        self.raised = False
+        if not use_global_err_message:
+            self.widget = QMessageBox(icon, title, "", buttons, parent)
+        else:
+            self.widget = None
+
+    def __enter__(self) -> "exceptions_as_dialog":
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        tb: TracebackType | None,
+    ) -> bool:
+        if not (exc_value is not None and isinstance(exc_value, self.exceptions)):
+            return False  # let it propagate
+
+        self.raised = True
+        if "tb" in self.msg_template:
+            _tb = "\n".join(traceback.format_exception(exc_type, exc_value, tb))
+        else:
+            _tb = ""
+        text = self.msg_template.format(exc_value=exc_value, exc_type=exc_type, tb=_tb)
+
+        if self.use_global_err_message:
+            global_err_message().showMessage(text)
+        elif self.widget is not None:
+            self.widget.setText(text)
+            self.widget.exec()  # could use the result to re-raise the exception
+
+        return True  # swallow the exception

--- a/src/superqt/utils/_errormsg_context.py
+++ b/src/superqt/utils/_errormsg_context.py
@@ -4,10 +4,14 @@ import traceback
 from contextlib import AbstractContextManager
 from typing import TYPE_CHECKING, cast
 
+from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QErrorMessage, QMessageBox, QWidget
 
 if TYPE_CHECKING:
     from types import TracebackType
+
+
+_DEFAULT_FLAGS = Qt.WindowType.Dialog | Qt.WindowType.MSWindowsFixedSizeDialogHint
 
 
 class exceptions_as_dialog(AbstractContextManager):
@@ -108,6 +112,7 @@ class exceptions_as_dialog(AbstractContextManager):
         msg_template: str = "{exc_value}",
         buttons: QMessageBox.StandardButton = QMessageBox.StandardButton.Ok,
         parent: QWidget | None = None,
+        flags: Qt.WindowType = _DEFAULT_FLAGS,
         use_error_message: bool | QErrorMessage = False,
     ):
         self.exceptions = exceptions
@@ -119,7 +124,9 @@ class exceptions_as_dialog(AbstractContextManager):
 
         if not use_error_message:
             # the message will be overwritten in __exit__
-            self.dialog = QMessageBox(icon, title, "An error occurred", buttons, parent)
+            self.dialog = QMessageBox(
+                icon, title, "An error occurred", buttons, parent, flags
+            )
 
     def __enter__(self) -> exceptions_as_dialog:
         return self

--- a/src/superqt/utils/_errormsg_context.py
+++ b/src/superqt/utils/_errormsg_context.py
@@ -49,7 +49,8 @@ class exceptions_as_dialog(AbstractContextManager):
         `msg_template`.) If `True`, the global `QMessageError.qtHandler()`
         instance is used to maintain a history of dismissed messages. You may also pass
         a `QErrorMessage` instance to use a specific instance. If `use_error_message` is
-        True, `parent` is ignored.
+        True, or if you pass your own `QErrorMessage` instance, the `parent` argument
+        is ignored.
 
     Attributes
     ----------

--- a/src/superqt/utils/_errormsg_context.py
+++ b/src/superqt/utils/_errormsg_context.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import traceback
 from contextlib import AbstractContextManager
 from types import TracebackType
@@ -30,7 +32,7 @@ class exceptions_as_dialog(AbstractContextManager):
         raise Exception("This message will be used as 'exc_value'")
 
     for _i in range(3):
-        with exceptions_as_dialog(AssertionError, global_err_message=True):
+        with exceptions_as_dialog(AssertionError, use_global_err_message=True):
             assert False, "Uncheck the checkbox to ignore this in the future"
     ```
     """
@@ -57,7 +59,7 @@ class exceptions_as_dialog(AbstractContextManager):
         else:
             self.widget = None
 
-    def __enter__(self) -> "exceptions_as_dialog":
+    def __enter__(self) -> exceptions_as_dialog:
         return self
 
     def __exit__(

--- a/src/superqt/utils/_errormsg_context.py
+++ b/src/superqt/utils/_errormsg_context.py
@@ -86,6 +86,12 @@ class exceptions_as_dialog(AbstractContextManager):
         with exceptions_as_dialog(AssertionError, use_error_message=True):
             assert False, "Uncheck the checkbox to ignore this in the future"
 
+    # use ctx.dialog to get the result of the dialog
+    btns = QMessageBox.StandardButton.Ok | QMessageBox.StandardButton.Cancel
+    with exceptions_as_dialog(buttons=btns) as ctx:
+        raise Exception("This will be caught and shown in a QMessageBox")
+    print(ctx.dialog.result())  # prints which button was clicked
+
     app.exec()  # needed only for the use_error_message example to show
     ```
     """

--- a/src/superqt/utils/_errormsg_context.py
+++ b/src/superqt/utils/_errormsg_context.py
@@ -15,7 +15,7 @@ class exceptions_as_dialog(AbstractContextManager):
 
     To determine whether an exception was raised or not, check the `exception`
     attribute after the context manager has exited.  If `use_error_message` is `False`
-    (the default), you can also access the `widget` attribute to get/manipulate the
+    (the default), you can also access the `dialog` attribute to get/manipulate the
     `QMessageBox` instance.
 
     Parameters
@@ -49,7 +49,7 @@ class exceptions_as_dialog(AbstractContextManager):
 
     Attributes
     ----------
-    widget : QMessageBox | None
+    dialog : QMessageBox | None
         The `QMessageBox` instance that was created. If `use_error_message` is
         True, this will be `None`.
     exception : BaseException | None
@@ -84,8 +84,9 @@ class exceptions_as_dialog(AbstractContextManager):
     ```
     """
 
-    widget: QMessageBox | None
+    dialog: QMessageBox | None
     exception: BaseException | None
+    exec_result: int | None = None
 
     def __init__(
         self,
@@ -100,13 +101,13 @@ class exceptions_as_dialog(AbstractContextManager):
         self.exceptions = exceptions
         self.msg_template = msg_template
         self.exception = None
-        self.widget = None
+        self.dialog = None
 
         self._err_msg = use_error_message
 
         if not use_error_message:
             # the message will be overwritten in __exit__
-            self.widget = QMessageBox(icon, title, "An error occurred", buttons, parent)
+            self.dialog = QMessageBox(icon, title, "An error occurred", buttons, parent)
 
     def __enter__(self) -> exceptions_as_dialog:
         return self
@@ -138,8 +139,8 @@ class exceptions_as_dialog(AbstractContextManager):
                 else QErrorMessage.qtHandler()
             )
             cast("QErrorMessage", msg).showMessage(text)
-        elif self.widget is not None:  # it won't be if use_error_message=False
-            self.widget.setText(text)
-            self.widget.exec()  # the result here could be stored in a variable
+        elif self.dialog is not None:  # it won't be if use_error_message=False
+            self.dialog.setText(text)
+            self.dialog.exec()
 
         return True  # swallow the exception

--- a/src/superqt/utils/_errormsg_context.py
+++ b/src/superqt/utils/_errormsg_context.py
@@ -13,6 +13,8 @@ if TYPE_CHECKING:
 class exceptions_as_dialog(AbstractContextManager):
     """Context manager that shows a dialog when an exception is raised.
 
+    See examples below for common usage patterns.
+
     To determine whether an exception was raised or not, check the `exception`
     attribute after the context manager has exited.  If `use_error_message` is `False`
     (the default), you can also access the `dialog` attribute to get/manipulate the
@@ -25,7 +27,7 @@ class exceptions_as_dialog(AbstractContextManager):
     icon : QMessageBox.Icon, optional
         The icon to show in the QMessageBox, by default `QMessageBox.Icon.Critical`
     title : str, optional
-        The title of the `QMessageBox`, by default "An error occurred"
+        The title of the `QMessageBox`, by default `"An error occurred"`.
     msg_template : str, optional
         The message to show in the `QMessageBox`. The message will be formatted
         using three variables:
@@ -52,13 +54,14 @@ class exceptions_as_dialog(AbstractContextManager):
     Attributes
     ----------
     dialog : QMessageBox | None
-        The `QMessageBox` instance that was created. If `use_error_message` is
-        True, this will be `None`.
+        The `QMessageBox` instance that was created (if `use_error_message` was
+        `False`).  This can be used, among other things, to determine the result of
+        the dialog (e.g. `dialog.result()`) or to manipulate the dialog (e.g.
+        `dialog.setDetailedText("some text")`).
     exception : BaseException | None
-        Will hold the exception instance if an exception was raised and caught. This
-        can be used to determine whether an exception was raised or not.
+        Will hold the exception instance if an exception was raised and caught.
 
-    Example
+    Examplez
     -------
     ```python
     from qtpy.QtWidgets import QApplication

--- a/src/superqt/utils/_errormsg_context.py
+++ b/src/superqt/utils/_errormsg_context.py
@@ -2,22 +2,58 @@ from __future__ import annotations
 
 import traceback
 from contextlib import AbstractContextManager
-from types import TracebackType
+from typing import TYPE_CHECKING, cast
 
 from qtpy.QtWidgets import QErrorMessage, QMessageBox, QWidget
 
-_GLOBAL_ERR = None
-
-
-def global_err_message() -> QErrorMessage:
-    global _GLOBAL_ERR
-    if _GLOBAL_ERR is None:
-        _GLOBAL_ERR = QErrorMessage()
-    return _GLOBAL_ERR
-
+if TYPE_CHECKING:
+    from types import TracebackType
 
 class exceptions_as_dialog(AbstractContextManager):
-    """Context manager that shows a QMessageBox when an exception is raised.
+    """Context manager that shows a dialog when an exception is raised.
+
+    To determine whether an exception was raised or not, check the `exception`
+    attribute after the context manager has exited.  If `use_error_message` is `False`
+    (the default), you can also access the `widget` attribute to get/manipulate the
+    `QMessageBox` instance.
+
+    Parameters
+    ----------
+    exceptions : type[BaseException] | tuple[type[BaseException], ...], optional
+        The exception(s) to catch, by default `Exception` (i.e. all exceptions).
+    icon : QMessageBox.Icon, optional
+        The icon to show in the QMessageBox, by default `QMessageBox.Icon.Critical`
+    title : str, optional
+        The title of the `QMessageBox`, by default "An error occurred"
+    msg_template : str, optional
+        The message to show in the `QMessageBox`. The message will be formatted
+        using three variables:
+        - `exc_value`: the exception instance
+        - `exc_type`: the exception type
+        - `tb`: the traceback as a string
+        The default template is the content of the exception: `"{exc_value}"`
+    buttons : QMessageBox.StandardButton, optional
+        The buttons to show in the `QMessageBox`, by default
+        `QMessageBox.StandardButton.Ok`
+    parent : QWidget | None, optional
+        The parent widget of the `QMessageBox`, by default `None`
+    use_error_message : bool | QErrorMessage, optional
+        Whether to use a `QErrorMessage` instead of a `QMessageBox`. By default
+        `False`. `QErrorMessage` shows a checkbox that the user can check to
+        prevent seeing the message again (based on the text of the formatted
+        `msg_template`.) If `True`, the global `QMessageError.qtHandler()`
+        instance is used to maintain a history of dismissed messages. You may also pass
+        a `QErrorMessage` instance to use a specific instance. If `use_error_message` is
+        True, `parent` is ignored.
+
+    Attributes
+    ----------
+    widget : QMessageBox | None
+        The `QMessageBox` instance that was created. If `use_error_message` is
+        True, this will be `None`.
+    exception : BaseException | None
+        Will hold the exception instance if an exception was raised and caught. This
+        can be used to determine whether an exception was raised or not.
 
     Example
     -------
@@ -32,32 +68,34 @@ class exceptions_as_dialog(AbstractContextManager):
         raise Exception("This message will be used as 'exc_value'")
 
     for _i in range(3):
-        with exceptions_as_dialog(AssertionError, use_global_err_message=True):
+        with exceptions_as_dialog(AssertionError, use_error_message=True):
             assert False, "Uncheck the checkbox to ignore this in the future"
     ```
     """
 
     widget: QMessageBox | None
-    raised: bool
+    exception: BaseException | None
 
     def __init__(
         self,
-        exceptions: type[BaseException] | tuple[type[BaseException], ...] = (Exception),
+        exceptions: type[BaseException] | tuple[type[BaseException], ...] = Exception,
         icon: QMessageBox.Icon = QMessageBox.Icon.Critical,
         title: str = "An error occurred",
         msg_template: str = "{exc_value}",
         buttons: QMessageBox.StandardButton = QMessageBox.StandardButton.Ok,
         parent: QWidget | None = None,
-        use_global_err_message: bool = False,
+        use_error_message: bool | QErrorMessage = False,
     ):
         self.exceptions = exceptions
         self.msg_template = msg_template
-        self.use_global_err_message = use_global_err_message
-        self.raised = False
-        if not use_global_err_message:
-            self.widget = QMessageBox(icon, title, "", buttons, parent)
-        else:
-            self.widget = None
+        self.exception = None
+        self.widget = None
+
+        self._err_msg = use_error_message
+
+        if not use_error_message:
+            # the message will be overwritten in __exit__
+            self.widget = QMessageBox(icon, title, "An error occurred", buttons, parent)
 
     def __enter__(self) -> exceptions_as_dialog:
         return self
@@ -71,17 +109,26 @@ class exceptions_as_dialog(AbstractContextManager):
         if not (exc_value is not None and isinstance(exc_value, self.exceptions)):
             return False  # let it propagate
 
-        self.raised = True
+        # save the exception for later
+        self.exception = exc_value
+
+        # format the message using the context variables
         if "{tb}" in self.msg_template:
             _tb = "\n".join(traceback.format_exception(exc_type, exc_value, tb))
         else:
             _tb = ""
         text = self.msg_template.format(exc_value=exc_value, exc_type=exc_type, tb=_tb)
 
-        if self.use_global_err_message:
-            global_err_message().showMessage(text)
-        elif self.widget is not None:
+        # show the dialog
+        if self._err_msg:
+            msg = (
+                self._err_msg
+                if isinstance(self._err_msg, QErrorMessage)
+                else QErrorMessage.qtHandler()
+            )
+            cast("QErrorMessage", msg).showMessage(text)
+        elif self.widget is not None:  # it won't be if use_error_message=False
             self.widget.setText(text)
-            self.widget.exec()  # could use the result to re-raise the exception
+            self.widget.exec()  # the result here could be stored in a variable
 
         return True  # swallow the exception

--- a/src/superqt/utils/_errormsg_context.py
+++ b/src/superqt/utils/_errormsg_context.py
@@ -72,7 +72,7 @@ class exceptions_as_dialog(AbstractContextManager):
             return False  # let it propagate
 
         self.raised = True
-        if "tb" in self.msg_template:
+        if "{tb}" in self.msg_template:
             _tb = "\n".join(traceback.format_exception(exc_type, exc_value, tb))
         else:
             _tb = ""

--- a/src/superqt/utils/_errormsg_context.py
+++ b/src/superqt/utils/_errormsg_context.py
@@ -9,6 +9,7 @@ from qtpy.QtWidgets import QErrorMessage, QMessageBox, QWidget
 if TYPE_CHECKING:
     from types import TracebackType
 
+
 class exceptions_as_dialog(AbstractContextManager):
     """Context manager that shows a dialog when an exception is raised.
 
@@ -58,18 +59,28 @@ class exceptions_as_dialog(AbstractContextManager):
     Example
     -------
     ```python
-    with exceptions_as_dialog():
+    from qtpy.QtWidgets import QApplication
+    from superqt.utils import exceptions_as_dialog
+
+    app = QApplication([])
+
+    with exceptions_as_dialog() as ctx:
         raise Exception("This will be caught and shown in a QMessageBox")
 
-    with exceptions_as_dialog(ValueError):
-        1 / 0  # ZeroDivisionError is not caught, so this will raise
+    # you can access the exception instance here
+    assert ctx.exception is not None
+
+    # with exceptions_as_dialog(ValueError):
+    #     1 / 0  # ZeroDivisionError is not caught, so this will raise
 
     with exceptions_as_dialog(msg_template="Error: {exc_value}"):
-        raise Exception("This message will be used as 'exc_value'")
+        raise Exception("This message will be inserted at 'exc_value'")
 
     for _i in range(3):
         with exceptions_as_dialog(AssertionError, use_error_message=True):
             assert False, "Uncheck the checkbox to ignore this in the future"
+
+    app.exec()  # needed only for the use_error_message example to show
     ```
     """
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,9 @@
+import os
+import sys
 from unittest.mock import Mock
 
 import pytest
+import qtpy
 from qtpy.QtCore import QObject, QTimer, Signal
 from qtpy.QtWidgets import QApplication, QErrorMessage, QMessageBox
 
@@ -95,6 +98,12 @@ def test_get_max_args_methods():
     assert get_max_args(A()) == 2
 
 
+MAC_CI_PYSIDE6 = bool(
+    sys.platform == "darwin" and os.getenv("CI") and qtpy.API_NAME == "PySide6"
+)
+
+
+@pytest.mark.skipif(MAC_CI_PYSIDE6, reason="still hangs on mac ci with pyside6")
 def test_exception_context(qtbot, qapp: QApplication) -> None:
     def accept():
         for wdg in qapp.topLevelWidgets():


### PR DESCRIPTION
```python
from qtpy.QtWidgets import QApplication

from superqt.utils import exceptions_as_dialog

app = QApplication([])

with exceptions_as_dialog():
    raise Exception("This will be caught and shown in a QMessageBox")

# with exceptions_as_dialog(ValueError):
#     1 / 0  # ZeroDivisionError is not caught, so this will raise

with exceptions_as_dialog(msg_template="Error: {exc_value}"):
    raise Exception("This message will be used as 'exc_value'")

for _i in range(3):
    with exceptions_as_dialog(AssertionError, use_global_err_message=True):
        raise AssertionError("Uncheck the checkbox to ignore this in the future")

app.exec()
```