### PR TITLE
fix: don't reuse text in qcollapsible

### DIFF
--- a/src/superqt/collapsible/_collapsible.py
+++ b/src/superqt/collapsible/_collapsible.py
@@ -66,8 +66,7 @@ class QCollapsible(QFrame):
 
     def setText(self, text: str) -> None:
         """Set the text of the toggle button."""
-        current = self._toggle_btn.text()
-        self._toggle_btn.setText(current + text)
+        self._toggle_btn.setText(text)
 
     def text(self) -> str:
         """Return the text of the toggle button."""


### PR DESCRIPTION
fixes #203 

not quite sure why that was like that ... might have been a combination of #140  not updating #37?  
but i think it's fine just to remove it