### PR TITLE
Fix IntEnum for python 3.11

### DIFF
--- a/src/superqt/combobox/_enum_combobox.py
+++ b/src/superqt/combobox/_enum_combobox.py
@@ -12,10 +12,8 @@ NONE_STRING = "----"
 
 def _get_name(enum_value: Enum):
     """Create human readable name if user does not implement `__str__`."""
-    if (
-        enum_value.__str__.__module__ != "enum"
-        and not enum_value.__str__.__module__.startswith("shibokensupport")
-    ):
+    str_module = getattr(enum_value.__str__, "__module__", "enum")
+    if str_module != "enum" and not str_module.startswith("shibokensupport"):
         # check if function was overloaded
         name = str(enum_value)
     else:

--- a/tests/test_enum_comb_box.py
+++ b/tests/test_enum_comb_box.py
@@ -1,4 +1,4 @@
-from enum import Enum
+from enum import Enum, IntEnum
 
 import pytest
 
@@ -34,6 +34,12 @@ class Enum4(Enum):
     a_1 = 1
     b_2 = 2
     c_3 = 3
+
+
+class IntEnum1(IntEnum):
+    a = 1
+    b = 2
+    c = 5
 
 
 def test_simple_create(qtbot):
@@ -129,3 +135,10 @@ def test_optional(qtbot):
     enum.setCurrentEnum(None)
     assert enum.currentText() == NONE_STRING
     assert enum.currentEnum() is None
+
+
+def test_simple_create_int_enum(qtbot):
+    enum = QEnumComboBox(enum_class=IntEnum1)
+    qtbot.addWidget(enum)
+    assert enum.count() == 3
+    assert [enum.itemText(i) for i in range(enum.count())] == ["a", "b", "c"]


### PR DESCRIPTION
Closes #202 

The error described in #202 is Python 3.11 specific. Caused by this change:

> Changed in version 3.11: [__str__()](https://docs.python.org/3/reference/datamodel.html#object.__str__) is now int.__str__() to better support the replacement of existing constants use-case. [__format__()](https://docs.python.org/3/reference/datamodel.html#object.__format__) was already int.__format__() for that same reason.

Described in [documentation](https://docs.python.org/3/library/enum.html#enum.IntEnum). 

I have changed the `_get_name` strategy to assume that if we cannot determine the `__str__` module, then we could assume that it is not overwritten by the user and use the default strategy. 
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- Bug Fix: Enhanced the `_get_name` function in `src/superqt/combobox/_enum_combobox.py` to handle cases where the `__str__` method of the `enum_value` object is overridden or belongs to a different module. This ensures more robust and reliable functionality.
- Test: Added a new test case `test_simple_create_int_enum` in `tests/test_enum_comb_box.py` to verify the correct creation of a `QEnumComboBox` with an `IntEnum1` class, improving the overall test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->