### PR TITLE
Add support for flag enum

### DIFF
--- a/src/superqt/combobox/_enum_combobox.py
+++ b/src/superqt/combobox/_enum_combobox.py
@@ -1,3 +1,4 @@
+import sys
 from enum import Enum, EnumMeta, Flag
 from functools import reduce
 from itertools import combinations
@@ -20,7 +21,20 @@ def _get_name(enum_value: Enum):
         # check if function was overloaded
         name = str(enum_value)
     else:
-        name = enum_value.name.replace("_", " ")
+        if enum_value.name is None:
+            # This is hack for python bellow 3.11
+            if not isinstance(enum_value, Flag):
+                raise TypeError(
+                    f"Expected Flag instance, got {enum_value}"
+                )  # pragma: no cover
+            if sys.version_info >= (3, 11):
+                return f"{enum_value.value}"
+            from enum import _decompose
+
+            members, not_covered = _decompose(enum_value.__class__, enum_value.value)
+            name = "|".join(m.name.replace("_", " ") for m in members[::-1])
+        else:
+            name = enum_value.name.replace("_", " ")
     return name
 
 

--- a/src/superqt/combobox/_enum_combobox.py
+++ b/src/superqt/combobox/_enum_combobox.py
@@ -28,7 +28,16 @@ def _get_name(enum_value: Enum):
                     f"Expected Flag instance, got {enum_value}"
                 )  # pragma: no cover
             if sys.version_info >= (3, 11):
+                # There is a bug in some releases of Python 3.11 (for example 3.11.3)
+                # that leads to wrong evaluation of or operation on Flag members
+                # and produces numeric value without proper set name property.
                 return f"{enum_value.value}"
+
+            # Before python 3.11 there is no smart name set during
+            # the creation of Flag members.
+            # We needs to decompose the value to get the name.
+            # It is under if condition because it uses private API.
+
             from enum import _decompose
 
             members, not_covered = _decompose(enum_value.__class__, enum_value.value)

--- a/src/superqt/combobox/_enum_combobox.py
+++ b/src/superqt/combobox/_enum_combobox.py
@@ -1,4 +1,7 @@
-from enum import Enum, EnumMeta
+from enum import Enum, EnumMeta, Flag
+from functools import reduce
+from itertools import combinations
+from operator import or_
 from typing import Optional, TypeVar
 
 from qtpy.QtCore import Signal
@@ -47,7 +50,14 @@ class QEnumComboBox(QComboBox):
         self._allow_none = allow_none and enum is not None
         if allow_none:
             super().addItem(NONE_STRING)
-        names = map(_get_name, self._enum_class.__members__.values())
+        if issubclass(enum, Flag):
+            members = list(self._enum_class.__members__.values())
+            comb_list = []
+            for i in range(len(members)):
+                comb_list.extend(reduce(or_, x) for x in combinations(members, i + 1))
+            names = map(_get_name, comb_list)
+        else:
+            names = map(_get_name, self._enum_class.__members__.values())
         _names = dict.fromkeys(names)  # remove duplicates/aliases, keep order
         super().addItems(list(_names))
 

--- a/tests/test_enum_comb_box.py
+++ b/tests/test_enum_comb_box.py
@@ -177,6 +177,8 @@ def test_enum_flag_create(qtbot, enum_class):
         "b|c",
         "a|b|c",
     ]
+    enum.setCurrentText("a|b")
+    assert enum.currentEnum() == enum_class.a | enum_class.b
 
 
 def test_enum_flag_create_collision(qtbot):

--- a/tests/test_enum_comb_box.py
+++ b/tests/test_enum_comb_box.py
@@ -198,53 +198,6 @@ def test_enum_flag_create_collision(qtbot):
 
 
 @pytest.mark.skipif(
-    sys.version_info < (3, 11), reason="different representation in 3.11"
-)
-def test_enum_flag_create_collision_not_covered_py311(qtbot):
-    enum = QEnumComboBox(enum_class=Flag2)
-    qtbot.addWidget(enum)
-    assert [enum.itemText(i) for i in range(enum.count())] == [
-        "a",
-        "b",
-        "c",
-        "a|b",
-        "a|b|4",
-    ]
-
-
-@pytest.mark.skipif(
-    sys.version_info >= (3, 11), reason="different representation in 3.11"
-)
-def test_enum_flag_create_collision_not_covered(qtbot):
-    enum = QEnumComboBox(enum_class=Flag2)
-    qtbot.addWidget(enum)
-    assert [enum.itemText(i) for i in range(enum.count())] == [
-        "a",
-        "b",
-        "c",
-        "a|b",
-        "a|b|c",
-    ]
-
-
-@pytest.mark.skipif(
-    sys.version_info < (3, 11), reason="different representation in 3.11"
-)
-def test_enum_flag_create_collision_evaluated_to_seven_py311(qtbot):
-    enum = QEnumComboBox(enum_class=FlagOrNum)
-    qtbot.addWidget(enum)
-    assert [enum.itemText(i) for i in range(enum.count())] == [
-        "a",
-        "b",
-        "c",
-        "7",
-        "c|3",
-        "c|5",
-        "c|7",
-    ]
-
-
-@pytest.mark.skipif(
     sys.version_info >= (3, 11), reason="different representation in 3.11"
 )
 def test_enum_flag_create_collision_evaluated_to_seven(qtbot):

--- a/tests/test_enum_comb_box.py
+++ b/tests/test_enum_comb_box.py
@@ -1,4 +1,5 @@
-from enum import Enum, IntEnum
+import sys
+from enum import Enum, Flag, IntEnum, IntFlag
 
 import pytest
 
@@ -40,6 +41,24 @@ class IntEnum1(IntEnum):
     a = 1
     b = 2
     c = 5
+
+
+class IntFlag1(IntFlag):
+    a = 1
+    b = 2
+    c = 4
+
+
+class Flag1(Flag):
+    a = 1
+    b = 2
+    c = 4
+
+
+class IntFlag2(IntFlag):
+    a = 1
+    b = 2
+    c = 3
 
 
 def test_simple_create(qtbot):
@@ -139,6 +158,46 @@ def test_optional(qtbot):
 
 def test_simple_create_int_enum(qtbot):
     enum = QEnumComboBox(enum_class=IntEnum1)
+    qtbot.addWidget(enum)
+    assert enum.count() == 3
+    assert [enum.itemText(i) for i in range(enum.count())] == ["a", "b", "c"]
+
+
+@pytest.mark.parametrize("enum_class", [IntFlag1, Flag1])
+def test_enum_flag_create(qtbot, enum_class):
+    enum = QEnumComboBox(enum_class=enum_class)
+    qtbot.addWidget(enum)
+    assert enum.count() == 7
+    assert [enum.itemText(i) for i in range(enum.count())] == [
+        "a",
+        "b",
+        "c",
+        "a|b",
+        "a|c",
+        "b|c",
+        "a|b|c",
+    ]
+
+
+def test_enum_flag_create_collision(qtbot):
+    enum = QEnumComboBox(enum_class=IntFlag2)
+    qtbot.addWidget(enum)
+    assert enum.count() == 3
+    assert [enum.itemText(i) for i in range(enum.count())] == ["a", "b", "c"]
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 11), reason="StrEnum is introduced in python 3.11"
+)
+def test_create_str_enum(qtbot):
+    from enum import StrEnum
+
+    class StrEnum1(StrEnum):
+        a = "a"
+        b = "b"
+        c = "c"
+
+    enum = QEnumComboBox(enum_class=StrEnum1)
     qtbot.addWidget(enum)
     assert enum.count() == 3
     assert [enum.itemText(i) for i in range(enum.count())] == ["a", "b", "c"]

--- a/tests/test_enum_comb_box.py
+++ b/tests/test_enum_comb_box.py
@@ -61,6 +61,18 @@ class IntFlag2(IntFlag):
     c = 3
 
 
+class Flag2(IntFlag):
+    a = 1
+    b = 2
+    c = 5
+
+
+class FlagOrNum(IntFlag):
+    a = 3
+    b = 5
+    c = 8
+
+
 def test_simple_create(qtbot):
     enum = QEnumComboBox(enum_class=Enum1)
     qtbot.addWidget(enum)
@@ -159,7 +171,6 @@ def test_optional(qtbot):
 def test_simple_create_int_enum(qtbot):
     enum = QEnumComboBox(enum_class=IntEnum1)
     qtbot.addWidget(enum)
-    assert enum.count() == 3
     assert [enum.itemText(i) for i in range(enum.count())] == ["a", "b", "c"]
 
 
@@ -167,7 +178,6 @@ def test_simple_create_int_enum(qtbot):
 def test_enum_flag_create(qtbot, enum_class):
     enum = QEnumComboBox(enum_class=enum_class)
     qtbot.addWidget(enum)
-    assert enum.count() == 7
     assert [enum.itemText(i) for i in range(enum.count())] == [
         "a",
         "b",
@@ -184,8 +194,71 @@ def test_enum_flag_create(qtbot, enum_class):
 def test_enum_flag_create_collision(qtbot):
     enum = QEnumComboBox(enum_class=IntFlag2)
     qtbot.addWidget(enum)
-    assert enum.count() == 3
     assert [enum.itemText(i) for i in range(enum.count())] == ["a", "b", "c"]
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 11), reason="different representation in 3.11"
+)
+def test_enum_flag_create_collision_not_covered_py311(qtbot):
+    enum = QEnumComboBox(enum_class=Flag2)
+    qtbot.addWidget(enum)
+    assert [enum.itemText(i) for i in range(enum.count())] == [
+        "a",
+        "b",
+        "c",
+        "a|b",
+        "a|b|4",
+    ]
+
+
+@pytest.mark.skipif(
+    sys.version_info >= (3, 11), reason="different representation in 3.11"
+)
+def test_enum_flag_create_collision_not_covered(qtbot):
+    enum = QEnumComboBox(enum_class=Flag2)
+    qtbot.addWidget(enum)
+    assert [enum.itemText(i) for i in range(enum.count())] == [
+        "a",
+        "b",
+        "c",
+        "a|b",
+        "a|b|c",
+    ]
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 11), reason="different representation in 3.11"
+)
+def test_enum_flag_create_collision_evaluated_to_seven_py311(qtbot):
+    enum = QEnumComboBox(enum_class=FlagOrNum)
+    qtbot.addWidget(enum)
+    assert [enum.itemText(i) for i in range(enum.count())] == [
+        "a",
+        "b",
+        "c",
+        "7",
+        "c|3",
+        "c|5",
+        "c|7",
+    ]
+
+
+@pytest.mark.skipif(
+    sys.version_info >= (3, 11), reason="different representation in 3.11"
+)
+def test_enum_flag_create_collision_evaluated_to_seven(qtbot):
+    enum = QEnumComboBox(enum_class=FlagOrNum)
+    qtbot.addWidget(enum)
+    assert [enum.itemText(i) for i in range(enum.count())] == [
+        "a",
+        "b",
+        "c",
+        "a|b",
+        "a|c",
+        "b|c",
+        "a|b|c",
+    ]
 
 
 @pytest.mark.skipif(
@@ -201,5 +274,4 @@ def test_create_str_enum(qtbot):
 
     enum = QEnumComboBox(enum_class=StrEnum1)
     qtbot.addWidget(enum)
-    assert enum.count() == 3
     assert [enum.itemText(i) for i in range(enum.count())] == ["a", "b", "c"]


### PR DESCRIPTION
As followup #205 I have checked that we do not have a test for another enum base class. So I prevent future failures, I added tests and spotted that flag support was not fully functional as it does not support element combinations. 

Also add `StrEnum` test. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
### Summary by CodeRabbit

- New Feature: Enhanced the `QEnumComboBox` class to support `Flag` enums in addition to regular enums. This allows users to select multiple options from a combo box.
- Refactor: Improved the internal handling of enum classes in `QEnumComboBox` by introducing helper functions for retrieving enum member names and values.
- Test: Added comprehensive test cases for the new `Flag` enum support in `QEnumComboBox`, ensuring robust functionality and error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->