### PR TITLE
feat: connection_token to remember and easily disconnect (later) a number of connections

### DIFF
--- a/docs/utilities/signal_utils.md
+++ b/docs/utilities/signal_utils.md
@@ -1,3 +1,7 @@
 # Signal Utilities
 
 ::: superqt.utils.signals_blocked
+
+::: superqt.utils.connection_token
+
+::: superqt.utils.temporary_connections

--- a/src/superqt/utils/__init__.py
+++ b/src/superqt/utils/__init__.py
@@ -5,8 +5,8 @@ if TYPE_CHECKING:
 
 __all__ = (
     "CodeSyntaxHighlight",
+    "connection_token",
     "create_worker",
-    "qimage_to_array",
     "draw_colormap",
     "ensure_main_thread",
     "ensure_object_thread",
@@ -15,11 +15,13 @@ __all__ = (
     "GeneratorWorker",
     "new_worker_qthread",
     "qdebounced",
+    "qimage_to_array",
     "QMessageHandler",
     "QSignalDebouncer",
     "QSignalThrottler",
     "qthrottled",
     "signals_blocked",
+    "temporary_connections",
     "thread_worker",
     "WorkerBase",
 )
@@ -29,7 +31,7 @@ from ._ensure_thread import ensure_main_thread, ensure_object_thread
 from ._errormsg_context import exceptions_as_dialog
 from ._img_utils import qimage_to_array
 from ._message_handler import QMessageHandler
-from ._misc import signals_blocked
+from ._misc import connection_token, signals_blocked, temporary_connections
 from ._qthreading import (
     FunctionWorker,
     GeneratorWorker,

--- a/src/superqt/utils/_misc.py
+++ b/src/superqt/utils/_misc.py
@@ -1,8 +1,11 @@
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Iterator
+from typing import TYPE_CHECKING, Any, Iterator
+from unittest.mock import patch
+
+from qtpy.QtCore import QObject, SignalInstance
 
 if TYPE_CHECKING:
-    from qtpy.QtCore import QObject
+    from qtpy.QtCore import QMetaObject
 
 
 @contextmanager
@@ -30,3 +33,86 @@ def signals_blocked(obj: "QObject") -> Iterator[None]:
         yield
     finally:
         obj.blockSignals(previous)
+
+
+CONNECT = SignalInstance.connect
+
+
+class connection_token:
+    """Context manager in which all connections are stored for later disconnection.
+
+    This provides a convenient way to remember a number of connections for easy
+    disconnection later.
+
+    Examples
+    --------
+    ```python
+    from qtpy.QtCore import QObject, Signal
+    from superqt.utils import connection_token
+
+    class Thing(QObject):
+        sig = Signal(int)
+
+    t = Thing()
+    with connection_token() as token:
+        t.sig.connect(lambda v: print("called with", v))
+        t.sig.connect(lambda: print("hey!"))
+        t.sig.connect(lambda: print("anyone there?"))
+
+    t.sig.emit(2)  # prints a bunch of stuff
+
+    token.disconnect()
+    t.sig.emit(4)  # nothing happens
+    ```
+    """
+
+    def __init__(self) -> None:
+        self._connections: list[QMetaObject.Connection] = []
+
+        # will be mocked in for SignalInstance.connect
+        def _store_connection(*args, **kwargs):
+            # perform the connection
+            connection = CONNECT(*args, **kwargs)
+            # store the connection for later disconnection
+            self._connections.append(connection)
+            return connection
+
+        # create a patcher for SignalInstance.connect
+        self._patch_connect = patch.object(SignalInstance, "connect", _store_connection)
+
+    def __enter__(self) -> "connection_token":
+        """Start the patcher."""
+        self._patch_connect.start()
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        """Stop the patcher."""
+        self._patch_connect.stop()
+
+    def __len__(self) -> int:
+        return len(self._connections)
+
+    def disconnect(self) -> None:
+        """Disconnect all connections stored in this token."""
+        while self._connections:
+            QObject.disconnect(self._connections.pop())
+
+
+@contextmanager
+def temporary_connections() -> Iterator[connection_token]:
+    """Context in which all signal/slot connections are temporary.
+
+    Examples
+    --------
+    ```python
+    from superqt.utils import temporary_connections
+
+    with temporary_connections():
+        obj.some_signal.connect(some_callback)
+        obj.some_signal.emit()  # some_callback is called
+    obj.some_signal.emit()  # some_callback is not called
+    ```
+    """
+    with connection_token() as token:
+        yield token
+    token.disconnect()

--- a/src/superqt/utils/_misc.py
+++ b/src/superqt/utils/_misc.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, Iterator
 from unittest.mock import patch
@@ -9,7 +11,7 @@ if TYPE_CHECKING:
 
 
 @contextmanager
-def signals_blocked(obj: "QObject") -> Iterator[None]:
+def signals_blocked(obj: QObject) -> Iterator[None]:
     """Context manager to temporarily block signals emitted by QObject: `obj`.
 
     Parameters
@@ -80,7 +82,7 @@ class connection_token:
         # create a patcher for SignalInstance.connect
         self._patch_connect = patch.object(SignalInstance, "connect", _store_connection)
 
-    def __enter__(self) -> "connection_token":
+    def __enter__(self) -> connection_token:
         """Start the patcher."""
         self._patch_connect.start()
         return self

--- a/src/superqt/utils/_misc.py
+++ b/src/superqt/utils/_misc.py
@@ -74,7 +74,7 @@ class connection_token:
             # perform the connection
             connection = CONNECT(*args, **kwargs)
             # store the connection for later disconnection
-            self._connections.append(connection)
+            self.append(connection)
             return connection
 
         # create a patcher for SignalInstance.connect
@@ -91,6 +91,10 @@ class connection_token:
 
     def __len__(self) -> int:
         return len(self._connections)
+
+    def append(self, connection: QMetaObject.Connection) -> None:
+        """Manually store a connection."""
+        self._connections.append(connection)
 
     def disconnect(self) -> None:
         """Disconnect all connections stored in this token."""


### PR DESCRIPTION
I frequently use a pattern where I connect a bunch of things in an `__init__` function, and then later disconnect them during a `destroyed` callback or something.   Napari does this a lot as well, for example [here](https://github.com/tlambert03/napari/blob/main/napari/_qt/qt_main_window.py#L629-L669)... and that's error prone if you forget one of the connections in the other method.

 This provides a `connection_token` object that remembers a set of connections (optionally within a context manager) and can disconnect them all later.

```python
from qtpy.QtCore import QObject, Signal
from superqt.utils import connection_token

class Thing(QObject):
    sig = Signal(int)

t = Thing()
with connection_token() as token:
    t.sig.connect(lambda v: print("called with", v))
    t.sig.connect(lambda: print("hey!"))
    t.sig.connect(lambda: print("anyone there?"))

# you can also use append
token.append(t.sig.connect(print))

t.sig.emit(2)  # prints a bunch of stuff

token.disconnect()
t.sig.emit(4)  # nothing happens
```

There's also a `temporary_connections` context, which automatically disconnects

```python
from superqt.utils import temporary_connections

with temporary_connections():
    obj.some_signal.connect(some_callback)
    obj.some_signal.emit()  # some_callback is called
obj.some_signal.emit()  # some_callback is not called
```

@Czaki ?