### PR TITLE
feat: add QIcon backed by iconify

### DIFF
--- a/examples/iconify.py
+++ b/examples/iconify.py
@@ -1,0 +1,15 @@
+from qtpy.QtCore import QSize
+from qtpy.QtWidgets import QApplication, QPushButton
+
+from superqt import QIconifyIcon
+
+app = QApplication([])
+
+btn = QPushButton()
+
+# search https://icon-sets.iconify.design for available icon keys
+btn.setIcon(QIconifyIcon("fa:smile-o", color="blue"))
+btn.setIconSize(QSize(60, 60))
+btn.show()
+
+app.exec()

--- a/examples/iconify.py
+++ b/examples/iconify.py
@@ -6,7 +6,6 @@ from superqt import QIconifyIcon
 app = QApplication([])
 
 btn = QPushButton()
-
 # search https://icon-sets.iconify.design for available icon keys
 btn.setIcon(QIconifyIcon("fa:smile-o", color="blue"))
 btn.setIconSize(QSize(60, 60))

--- a/examples/iconify.py
+++ b/examples/iconify.py
@@ -7,7 +7,7 @@ app = QApplication([])
 
 btn = QPushButton()
 # search https://icon-sets.iconify.design for available icon keys
-btn.setIcon(QIconifyIcon("fa:smile-o", color="blue"))
+btn.setIcon(QIconifyIcon("fluent-emoji-flat:alarm-clock"))
 btn.setIconSize(QSize(60, 60))
 btn.show()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ font-fa5 = ["fonticon-fontawesome5"]
 font-fa6 = ["fonticon-fontawesome6"]
 font-mi6 = ["fonticon-materialdesignicons6"]
 font-mi7 = ["fonticon-materialdesignicons7"]
-iconify = ["pyconify"]
+iconify = ["pyconify >=0.1.2"]
 
 [project.urls]
 Documentation = "https://pyapp-kit.github.io/superqt/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ font-fa5 = ["fonticon-fontawesome5"]
 font-fa6 = ["fonticon-fontawesome6"]
 font-mi6 = ["fonticon-materialdesignicons6"]
 font-mi7 = ["fonticon-materialdesignicons7"]
-iconify = ["pyconify >=0.1.2"]
+iconify = ["pyconify >=0.1.3"]
 
 [project.urls]
 Documentation = "https://pyapp-kit.github.io/superqt/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ font-fa5 = ["fonticon-fontawesome5"]
 font-fa6 = ["fonticon-fontawesome6"]
 font-mi6 = ["fonticon-materialdesignicons6"]
 font-mi7 = ["fonticon-materialdesignicons7"]
+iconify = ["pyconify"]
 
 [project.urls]
 Documentation = "https://pyapp-kit.github.io/superqt/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
 # extras
 # https://peps.python.org/pep-0621/#dependencies-optional-dependencies
 [project.optional-dependencies]
-test = ["pint", "pytest", "pytest-cov", "pytest-qt", "numpy", "cmap"]
+test = ["pint", "pytest", "pytest-cov", "pytest-qt", "numpy", "cmap", "pyconify"]
 dev = [
     "black",
     "ipython",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ font-fa5 = ["fonticon-fontawesome5"]
 font-fa6 = ["fonticon-fontawesome6"]
 font-mi6 = ["fonticon-materialdesignicons6"]
 font-mi7 = ["fonticon-materialdesignicons7"]
-iconify = ["pyconify >=0.1.3"]
+iconify = ["pyconify >=0.1.4"]
 
 [project.urls]
 Documentation = "https://pyapp-kit.github.io/superqt/"

--- a/src/superqt/__init__.py
+++ b/src/superqt/__init__.py
@@ -10,6 +10,7 @@ except PackageNotFoundError:
 from .collapsible import QCollapsible
 from .combobox import QColorComboBox, QEnumComboBox, QSearchableComboBox
 from .elidable import QElidingLabel, QElidingLineEdit
+from .iconify import QIconifyIcon
 from .selection import QSearchableListWidget, QSearchableTreeWidget
 from .sliders import (
     QDoubleRangeSlider,
@@ -35,6 +36,7 @@ __all__ = [
     "QElidingLineEdit",
     "QEnumComboBox",
     "QLabeledDoubleRangeSlider",
+    "QIconifyIcon",
     "QLabeledDoubleSlider",
     "QLabeledRangeSlider",
     "QLabeledSlider",

--- a/src/superqt/fonticon/__init__.py
+++ b/src/superqt/fonticon/__init__.py
@@ -10,6 +10,7 @@ __all__ = [
     "IconFontMeta",
     "IconOpts",
     "pulse",
+    "QIconifyIcon",
     "setTextIcon",
     "spin",
 ]

--- a/src/superqt/iconify/__init__.py
+++ b/src/superqt/iconify/__init__.py
@@ -34,15 +34,13 @@ class QIconifyIcon(QIcon):
         Icon set prefix and name. May be passed as a single string in the format
         `"prefix:name"` or as two separate strings: `'prefix', 'name'`.
     color : str, optional
-        Icon color. Replaces currentColor with specific color, resulting in icon with
-        hardcoded palette.
+        Icon color. If not provided, the icon will appear black (the icon fill color
+        will be set to the string "currentColor").
     flip : str, optional
-        Flip icon.
+        Flip icon.  Must be one of "horizontal", "vertical", "horizontal,vertical"
     rotate : str | int, optional
-        Rotate icon. If an integer is provided, it is assumed to be in degrees.
-    prefix : str, optional
-        If not None, the temp file name will begin with that prefix, otherwise a default
-        prefix is used.
+        Rotate icon. Must be one of 90, 180, 270,
+        or 1, 2, 3 (equivalent to 90, 180, 270, respectively)
     dir : str, optional
         If 'dir' is not None, the file will be created in that directory, otherwise a
         default directory is used.
@@ -62,7 +60,6 @@ class QIconifyIcon(QIcon):
         color: str | None = None,
         flip: Flip | None = None,
         rotate: Rotation | None = None,
-        prefix: str | None = None,
         dir: str | None = None,
     ):
         try:
@@ -72,7 +69,5 @@ class QIconifyIcon(QIcon):
                 "pyconify is required to use QIconifyIcon. "
                 "Please install it with `pip install pyconify`"
             ) from None
-        self.path = temp_svg(
-            *key, color=color, flip=flip, rotate=rotate, prefix=prefix, dir=dir
-        )
+        self.path = temp_svg(*key, color=color, flip=flip, rotate=rotate, dir=dir)
         super().__init__(self.path)

--- a/src/superqt/iconify/__init__.py
+++ b/src/superqt/iconify/__init__.py
@@ -65,7 +65,7 @@ class QIconifyIcon(QIcon):
     ):
         try:
             from pyconify import svg_path
-        except ModuleNotFoundError as e:
+        except ModuleNotFoundError as e:  # pragma: no cover
             raise ImportError(
                 "pyconify is required to use QIconifyIcon. "
                 "Please install it with `pip install pyconify` or use the "

--- a/src/superqt/iconify/__init__.py
+++ b/src/superqt/iconify/__init__.py
@@ -22,7 +22,7 @@ class QIconifyIcon(QIcon):
     icon:  `QIconifyIcon("bi:bell")`.
 
     This class is a thin wrapper around the
-    [pyconify](https://github.com/pyapp-kit/pyconify) `temp_svg` function. It pulls SVGs
+    [pyconify](https://github.com/pyapp-kit/pyconify) `svg_path` function. It pulls SVGs
     from iconify, creates a temporary SVG file and uses it as the source for a QIcon.
     SVGs are cached to disk, and persist across sessions (until `pyconify.clear_cache()`
     is called).

--- a/src/superqt/iconify/__init__.py
+++ b/src/superqt/iconify/__init__.py
@@ -38,11 +38,13 @@ class QIconifyIcon(QIcon):
     flip : str, optional
         Flip icon.  Must be one of "horizontal", "vertical", "horizontal,vertical"
     rotate : str | int, optional
-        Rotate icon. Must be one of 90, 180, 270,
-        or 1, 2, 3 (equivalent to 90, 180, 270, respectively)
+        Rotate icon. Must be one of 0, 90, 180, 270,
+        or 0, 1, 2, 3 (equivalent to 0, 90, 180, 270, respectively)
     dir : str, optional
         If 'dir' is not None, the file will be created in that directory, otherwise a
-        default [directory](https://docs.python.org/3/library/tempfile.html#tempfile.mkstemp) is used.
+        default
+        [directory](https://docs.python.org/3/library/tempfile.html#tempfile.mkstemp) is
+        used.
 
     Examples
     --------
@@ -62,11 +64,12 @@ class QIconifyIcon(QIcon):
         dir: str | None = None,
     ):
         try:
-            from pyconify import temp_svg
+            from pyconify import svg_path
         except ModuleNotFoundError as e:
             raise ImportError(
                 "pyconify is required to use QIconifyIcon. "
-                "Please install it with `pip install pyconify`"
+                "Please install it with `pip install iconify` or use the "
+                "`pip install superqt[iconify]` extra."
             ) from e
-        self.path = temp_svg(*key, color=color, flip=flip, rotate=rotate, dir=dir)
+        self.path = svg_path(*key, color=color, flip=flip, rotate=rotate, dir=dir)
         super().__init__(self.path)

--- a/src/superqt/iconify/__init__.py
+++ b/src/superqt/iconify/__init__.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from qtpy.QtGui import QIcon
+
+if TYPE_CHECKING:
+    from typing import Literal
+
+    Flip = Literal["horizontal", "vertical", "horizontal,vertical"]
+    Rotation = Literal["90", "180", "270", 90, 180, 270, "-90", 1, 2, 3]
+
+
+class QIconifyIcon(QIcon):
+    """QIcon backed by an iconify icon.
+
+    This class is a thin wrapper around the
+    [pyconify](https://github.com/pyapp-kit/pyconify) `temp_svg` function. It creates a
+    temporary SVG file and uses it as the source for a QIcon. SVGs are cached to disk,
+    and persist across sessions (until `pyconify.clear_cache()` is called).
+
+    Iconify includes 150,000+ icons from most major icon sets including Bootstrap,
+    FontAwesome, Material Design, and many more.
+
+    Search availble icons at https://icon-sets.iconify.design
+
+    Once you find one you like, use the key in the format `"prefix:name"` to create an
+    icon:  `QIconifyIcon("bi:bell")`.
+
+    Parameters
+    ----------
+    *key: str
+        Icon set prefix and name. May be passed as a single string in the format
+        `"prefix:name"` or as two separate strings: `'prefix', 'name'`.
+    color : str, optional
+        Icon color. Replaces currentColor with specific color, resulting in icon with
+        hardcoded palette.
+    flip : str, optional
+        Flip icon.
+    rotate : str | int, optional
+        Rotate icon. If an integer is provided, it is assumed to be in degrees.
+    prefix : str, optional
+        If not None, the temp file name will begin with that prefix, otherwise a default
+        prefix is used.
+    dir : str, optional
+        If 'dir' is not None, the file will be created in that directory, otherwise a
+        default directory is used.
+
+    Examples
+    --------
+    >>> from qtpy.QtWidgets import QPushButton
+    >>> from superqt import QIconifyIcon
+    >>> btn = QPushButton()
+    >>> icon = QIconifyIcon("bi:alarm-fill", color="red", rotate=90)
+    >>> btn.setIcon(icon)
+    """
+
+    def __init__(
+        self,
+        *key: str,
+        color: str | None = None,
+        flip: Flip | None = None,
+        rotate: Rotation | None = None,
+        prefix: str | None = None,
+        dir: str | None = None,
+    ):
+        try:
+            from pyconify import temp_svg
+        except ImportError:
+            raise ImportError(
+                "pyconify is required to use QIconifyIcon. "
+                "Please install it with `pip install pyconify`"
+            ) from None
+        self.path = temp_svg(
+            *key, color=color, flip=flip, rotate=rotate, prefix=prefix, dir=dir
+        )
+        super().__init__(self.path)

--- a/src/superqt/iconify/__init__.py
+++ b/src/superqt/iconify/__init__.py
@@ -68,7 +68,7 @@ class QIconifyIcon(QIcon):
         except ModuleNotFoundError as e:
             raise ImportError(
                 "pyconify is required to use QIconifyIcon. "
-                "Please install it with `pip install iconify` or use the "
+                "Please install it with `pip install pyconify` or use the "
                 "`pip install superqt[iconify]` extra."
             ) from e
         self.path = svg_path(*key, color=color, flip=flip, rotate=rotate, dir=dir)

--- a/src/superqt/iconify/__init__.py
+++ b/src/superqt/iconify/__init__.py
@@ -14,19 +14,18 @@ if TYPE_CHECKING:
 class QIconifyIcon(QIcon):
     """QIcon backed by an iconify icon.
 
+    Iconify includes 150,000+ icons from most major icon sets including Bootstrap,
+    FontAwesome, Material Design, and many more.
+
+    Search availble icons at https://icon-sets.iconify.design
+    Once you find one you like, use the key in the format `"prefix:name"` to create an
+    icon:  `QIconifyIcon("bi:bell")`.
+
     This class is a thin wrapper around the
     [pyconify](https://github.com/pyapp-kit/pyconify) `temp_svg` function. It pulls SVGs
     from iconify, creates a temporary SVG file and uses it as the source for a QIcon.
     SVGs are cached to disk, and persist across sessions (until `pyconify.clear_cache()`
     is called).
-
-    Iconify includes 150,000+ icons from most major icon sets including Bootstrap,
-    FontAwesome, Material Design, and many more.
-
-    Search availble icons at https://icon-sets.iconify.design
-
-    Once you find one you like, use the key in the format `"prefix:name"` to create an
-    icon:  `QIconifyIcon("bi:bell")`.
 
     Parameters
     ----------

--- a/src/superqt/iconify/__init__.py
+++ b/src/superqt/iconify/__init__.py
@@ -72,4 +72,4 @@ class QIconifyIcon(QIcon):
                 "`pip install superqt[iconify]` extra."
             ) from e
         self.path = svg_path(*key, color=color, flip=flip, rotate=rotate, dir=dir)
-        super().__init__(self.path)
+        super().__init__(str(self.path))

--- a/src/superqt/iconify/__init__.py
+++ b/src/superqt/iconify/__init__.py
@@ -63,10 +63,10 @@ class QIconifyIcon(QIcon):
     ):
         try:
             from pyconify import temp_svg
-        except ImportError:
+        except ModuleNotFoundError as e:
             raise ImportError(
                 "pyconify is required to use QIconifyIcon. "
                 "Please install it with `pip install pyconify`"
-            ) from None
+            ) from e
         self.path = temp_svg(*key, color=color, flip=flip, rotate=rotate, dir=dir)
         super().__init__(self.path)

--- a/src/superqt/iconify/__init__.py
+++ b/src/superqt/iconify/__init__.py
@@ -15,9 +15,10 @@ class QIconifyIcon(QIcon):
     """QIcon backed by an iconify icon.
 
     This class is a thin wrapper around the
-    [pyconify](https://github.com/pyapp-kit/pyconify) `temp_svg` function. It creates a
-    temporary SVG file and uses it as the source for a QIcon. SVGs are cached to disk,
-    and persist across sessions (until `pyconify.clear_cache()` is called).
+    [pyconify](https://github.com/pyapp-kit/pyconify) `temp_svg` function. It pulls SVGs
+    from iconify, creates a temporary SVG file and uses it as the source for a QIcon.
+    SVGs are cached to disk, and persist across sessions (until `pyconify.clear_cache()`
+    is called).
 
     Iconify includes 150,000+ icons from most major icon sets including Bootstrap,
     FontAwesome, Material Design, and many more.

--- a/src/superqt/iconify/__init__.py
+++ b/src/superqt/iconify/__init__.py
@@ -42,7 +42,7 @@ class QIconifyIcon(QIcon):
         or 1, 2, 3 (equivalent to 90, 180, 270, respectively)
     dir : str, optional
         If 'dir' is not None, the file will be created in that directory, otherwise a
-        default directory is used.
+        default [directory](https://docs.python.org/3/library/tempfile.html#tempfile.mkstemp) is used.
 
     Examples
     --------

--- a/tests/test_iconify.py
+++ b/tests/test_iconify.py
@@ -1,9 +1,11 @@
+import pytest
 from qtpy.QtWidgets import QPushButton
 
 from superqt import QIconifyIcon
 
 
 def test_qiconify(qtbot):
+    pytest.importorskip("pyconify")
     icon = QIconifyIcon("bi:alarm-fill", color="red", rotate=90)
     assert icon.path.endswith(".svg")
     btn = QPushButton()

--- a/tests/test_iconify.py
+++ b/tests/test_iconify.py
@@ -4,10 +4,13 @@ from qtpy.QtWidgets import QPushButton
 from superqt import QIconifyIcon
 
 
-def test_qiconify(qtbot):
+def test_qiconify(qtbot, tmp_path, monkeypatch):
+    monkeypatch.setenv("PYCONIFY_CACHE", "0")
+
     pytest.importorskip("pyconify")
-    icon = QIconifyIcon("bi:alarm-fill", color="red", rotate=90)
-    assert icon.path.endswith(".svg")
+    icon = QIconifyIcon("bi:alarm-fill", color="red", rotate=90, dir=tmp_path)
+    assert icon.path.name.endswith(".svg")
+    assert icon.path.parent == tmp_path
     btn = QPushButton()
     qtbot.addWidget(btn)
     btn.setIcon(icon)

--- a/tests/test_iconify.py
+++ b/tests/test_iconify.py
@@ -1,16 +1,21 @@
+from typing import TYPE_CHECKING
+
 import pytest
 from qtpy.QtWidgets import QPushButton
 
 from superqt import QIconifyIcon
 
+if TYPE_CHECKING:
+    from pytestqt.qtbot import QtBot
 
-def test_qiconify(qtbot, tmp_path, monkeypatch):
+
+def test_qiconify(qtbot: "QtBot", monkeypatch: "pytest.MonkeyPatch") -> None:
     monkeypatch.setenv("PYCONIFY_CACHE", "0")
-
     pytest.importorskip("pyconify")
-    icon = QIconifyIcon("bi:alarm-fill", color="red", rotate=90, dir=tmp_path)
+
+    icon = QIconifyIcon("bi:alarm-fill", color="red", rotate=90)
     assert icon.path.name.endswith(".svg")
-    assert icon.path.parent == tmp_path
+
     btn = QPushButton()
     qtbot.addWidget(btn)
     btn.setIcon(icon)

--- a/tests/test_iconify.py
+++ b/tests/test_iconify.py
@@ -1,0 +1,12 @@
+from qtpy.QtWidgets import QPushButton
+
+from superqt import QIconifyIcon
+
+
+def test_qiconify(qtbot):
+    icon = QIconifyIcon("bi:alarm-fill", color="red", rotate=90)
+    assert icon.path.endswith(".svg")
+    btn = QPushButton()
+    qtbot.addWidget(btn)
+    btn.setIcon(icon)
+    btn.show()


### PR DESCRIPTION
[Iconify](https://icon-sets.iconify.design) is a pretty great API unifying pretty much all of the major font-icon libraries into a single API from which you can request standardized SVGs.  I wrapped the API in library [`pyconify`](https://github.com/pyapp-kit/pyconify) that makes it easier to work with in python, and caches all svgs locally for faster/offline usage (after first using online once).  This PR makes a simple QIcon wrapper:

```python
from qtpy.QtCore import QSize
from qtpy.QtWidgets import QApplication, QPushButton

from superqt import QIconifyIcon

app = QApplication([])

btn = QPushButton()
# search https://icon-sets.iconify.design for available icon keys
btn.setIcon(QIconifyIcon("fa:smile-o", color="blue"))
btn.setIconSize(QSize(60, 60))
btn.show()

app.exec()
```

A downside of using this is that it's SVG based, which makes it a bit harder than font libraries to change colors simply using style sheets (like napari does for its themes... though even that may be possible).  A big upside is that you no longer need to include the whole font-family file just to grab a couple icons, and you can pick and choose from all of the libraries without having to bring in a new plugin for each one.  Also, for reasons beyond just color changing, SVGs are preferable in many cases to fonts (animations are possible, for example)