### PR TITLE
fix: don't enqueue Worker for deletion in `new_worker_qthread`

### DIFF
--- a/src/superqt/utils/_qthreading.py
+++ b/src/superqt/utils/_qthreading.py
@@ -881,6 +881,7 @@ def new_worker_qthread(
     worker.moveToThread(thread)
     thread.started.connect(worker.work)
     worker.finished.connect(thread.quit)
+    thread.finished.connect(worker.deleteLater)
     thread.finished.connect(thread.deleteLater)
 
     if _connect:

--- a/src/superqt/utils/_qthreading.py
+++ b/src/superqt/utils/_qthreading.py
@@ -881,7 +881,6 @@ def new_worker_qthread(
     worker.moveToThread(thread)
     thread.started.connect(worker.work)
     worker.finished.connect(thread.quit)
-    worker.finished.connect(worker.deleteLater)
     thread.finished.connect(thread.deleteLater)
 
     if _connect:


### PR DESCRIPTION
on a tip from @andy-sweet ... to better match the pattern shown in https://doc.qt.io/qt-6/qthread.html#details

@andy-sweet, let me know if you agree this is all that is needed