### PR TITLE
Bugfix: Check min max versus current value

### DIFF
--- a/src/superqt/spinbox/_intspin.py
+++ b/src/superqt/spinbox/_intspin.py
@@ -65,12 +65,16 @@ class QLargeIntSpinBox(QAbstractSpinBox):
 
     def setMinimum(self, min):
         self._minimum = int(min)
+        if self._minimum > self._value:
+            self.setValue(self._minimum)
 
     def maximum(self):
         return self._maximum
 
     def setMaximum(self, max):
         self._maximum = int(max)
+        if self._maximum < self._value:
+            self.setValue(self._maximum)
 
     def setRange(self, minimum, maximum):
         self.setMinimum(minimum)

--- a/src/superqt/spinbox/_intspin.py
+++ b/src/superqt/spinbox/_intspin.py
@@ -77,6 +77,8 @@ class QLargeIntSpinBox(QAbstractSpinBox):
             self.setValue(self._maximum)
 
     def setRange(self, minimum, maximum):
+        if maximum < minimum:
+            maximum = minimum
         self.setMinimum(minimum)
         self.setMaximum(maximum)
 

--- a/tests/test_large_int_spinbox.py
+++ b/tests/test_large_int_spinbox.py
@@ -21,6 +21,7 @@ def test_large_spinbox(qtbot):
         assert sgnl.args == [-(10**e)]
         assert sb.value() == -(10**e)
 
+
 def test_large_spinbox_range(qtbot):
     sb = QLargeIntSpinBox()
     qtbot.addWidget(sb)
@@ -29,6 +30,7 @@ def test_large_spinbox_range(qtbot):
 
     sb.setRange(-10, 10)
     assert sb.value() == 10
+
 
 def test_large_spinbox_type(qtbot):
     sb = QLargeIntSpinBox()

--- a/tests/test_large_int_spinbox.py
+++ b/tests/test_large_int_spinbox.py
@@ -34,6 +34,11 @@ def test_large_spinbox_range(qtbot):
     sb.setRange(100, 1000)
     assert sb.value() == 100
 
+    sb.setRange(50, 0)
+    assert sb.minimum() == 50
+    assert sb.maximum() == 50
+    assert sb.value() == 50
+
 
 def test_large_spinbox_type(qtbot):
     sb = QLargeIntSpinBox()

--- a/tests/test_large_int_spinbox.py
+++ b/tests/test_large_int_spinbox.py
@@ -21,6 +21,14 @@ def test_large_spinbox(qtbot):
         assert sgnl.args == [-(10**e)]
         assert sb.value() == -(10**e)
 
+def test_large_spinbox_range(qtbot):
+    sb = QLargeIntSpinBox()
+    qtbot.addWidget(sb)
+    sb.setRange(-100, 100)
+    sb.setValue(50)
+
+    sb.setRange(-10, 10)
+    assert sb.value() == 10
 
 def test_large_spinbox_type(qtbot):
     sb = QLargeIntSpinBox()

--- a/tests/test_large_int_spinbox.py
+++ b/tests/test_large_int_spinbox.py
@@ -31,6 +31,9 @@ def test_large_spinbox_range(qtbot):
     sb.setRange(-10, 10)
     assert sb.value() == 10
 
+    sb.setRange(100, 1000)
+    assert sb.value() == 100
+
 
 def test_large_spinbox_type(qtbot):
     sb = QLargeIntSpinBox()


### PR DESCRIPTION
Closes https://github.com/pyapp-kit/superqt/issues/220

As suggested by Grzegorz here https://github.com/pyapp-kit/superqt/issues/220#issuecomment-1824785806 in this PR I have setMin and setMax check versus the current value and if that is smaller/larger it's reset to min/max.

I also added a test for the issue that fails on current main, but passes with this fix.