### PR TITLE
fix: fix a number of issues with Labeled and Range Sliders, add LabelsOnHandle mode.

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -30,11 +30,11 @@ jobs:
       matrix:
         platform: [ubuntu-latest, windows-latest, macos-13]
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        backend: [pyqt5, pyside2, "'PyQt6<6.6'"]
+        backend: [pyqt5, pyside2, pyqt6]
         exclude:
           # Abort (core dumped) on linux pyqt6, unknown reason
           - platform: ubuntu-latest
-            backend: "'PyQt6<6.6'"
+            backend: pyqt6
           # lack of wheels for pyside2/py3.11
           - python-version: "3.11"
             backend: pyside2
@@ -56,7 +56,7 @@ jobs:
 
           - python-version: "3.12"
             platform: macos-latest
-            backend: "'PyQt6<6.6'"
+            backend: pyqt6
 
           # legacy Qt
           - python-version: 3.8

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -84,12 +84,13 @@ jobs:
       dependency-ref: ${{ matrix.napari-version }}
       dependency-extras: 'testing'
       qt: ${{ matrix.qt }}
-      pytest-args: 'napari/_qt -k "not async and not qt_dims_2"'
+      pytest-args: 'napari/_qt -k "not async and not qt_dims_2 and not qt_viewer_console_focus and not keybinding_editor"'
       python-version: "3.10"
+      post-install-cmd: 'pip install lxml_html_clean'
     strategy:
       fail-fast: false
       matrix:
-        napari-version: ["", "v0.4.18"]
+        napari-version: ["", "v0.4.19.post1"]
         qt: ["pyqt5", "pyside2"]
 
   check-manifest:

--- a/src/superqt/sliders/_generic_range_slider.py
+++ b/src/superqt/sliders/_generic_range_slider.py
@@ -124,11 +124,27 @@ class _GenericRangeSlider(_GenericSlider):
         """
         return tuple(float(i) for i in self._position)
 
-    def setSliderPosition(self, pos: Union[float, Sequence[float]], index=None) -> None:
+    def setSliderPosition(  # type: ignore
+        self,
+        pos: Union[float, Sequence[float]],
+        index: int | None = None,
+        *,
+        reversed: bool = False,
+    ) -> None:
         """Set current position of the handles with a sequence of integers.
 
-        If `pos` is a sequence, it must have the same length as `value()`.
-        If it is a scalar, index will be
+        Parameters
+        ----------
+        pos : Union[float, Sequence[float]]
+            The new position of the slider handle(s). If a sequence, it must have the
+            same length as `value()`. If it is a scalar, index will be used to set the
+            position of the handle at that index.
+        index : int | None
+            The index of the handle to set the position of. If None, the "pressedIndex"
+            will be used.
+        reversed : bool
+            Order in which to set the positions.  Can be useful when setting multiple
+            positions, to avoid intermediate overlapping values.
         """
         if isinstance(pos, (list, tuple)):
             val_len = len(self.value())
@@ -138,6 +154,9 @@ class _GenericRangeSlider(_GenericSlider):
             pairs = list(enumerate(pos))
         else:
             pairs = [(self._pressedIndex if index is None else index, pos)]
+
+        if reversed:
+            pairs = pairs[::-1]
 
         for idx, position in pairs:
             self._position[idx] = self._bound(position, idx)
@@ -222,7 +241,7 @@ class _GenericRangeSlider(_GenericSlider):
                 offset = self.maximum() - ref[-1]
             elif ref[0] + offset < self.minimum():
                 offset = self.minimum() - ref[0]
-        self.setSliderPosition([i + offset for i in ref])
+        self.setSliderPosition([i + offset for i in ref], reversed=offset > 0)
 
     def _fixStyleOption(self, option):
         pass

--- a/src/superqt/sliders/_generic_range_slider.py
+++ b/src/superqt/sliders/_generic_range_slider.py
@@ -103,7 +103,7 @@ class _GenericRangeSlider(_GenericSlider):
         """Show the bar between the first and last handle."""
         self.setBarVisible(True)
 
-    def applyMacStylePatch(self) -> str:
+    def applyMacStylePatch(self) -> None:
         """Apply a QSS patch to fix sliders on macos>=12 with QT < 6.
 
         see [FAQ](../faq.md#sliders-not-dragging-properly-on-macos-12) for more details.
@@ -127,7 +127,7 @@ class _GenericRangeSlider(_GenericSlider):
     def setSliderPosition(  # type: ignore
         self,
         pos: Union[float, Sequence[float]],
-        index: int | None = None,
+        index: Optional[int] = None,
         *,
         reversed: bool = False,
     ) -> None:

--- a/src/superqt/sliders/_generic_slider.py
+++ b/src/superqt/sliders/_generic_slider.py
@@ -99,7 +99,7 @@ class _GenericSlider(QSlider):
         if USE_MAC_SLIDER_PATCH:
             self.applyMacStylePatch()
 
-    def applyMacStylePatch(self) -> str:
+    def applyMacStylePatch(self) -> None:
         """Apply a QSS patch to fix sliders on macos>=12 with QT < 6.
 
         see [FAQ](../faq.md#sliders-not-dragging-properly-on-macos-12) for more details.

--- a/src/superqt/sliders/_generic_slider.py
+++ b/src/superqt/sliders/_generic_slider.py
@@ -342,8 +342,12 @@ class _GenericSlider(QSlider):
         option.sliderValue = self._to_qinteger_space(self._value - self._minimum)
 
     def _to_qinteger_space(self, val, _max=None):
+        """Converts a value to the internal integer space."""
         _max = _max or self.MAX_DISPLAY
-        return int(min(QOVERFLOW, val / (self._maximum - self._minimum) * _max))
+        range_ = self._maximum - self._minimum
+        if range_ == 0:
+            return self._minimum
+        return int(min(QOVERFLOW, val / range_ * _max))
 
     def _pick(self, pt: QPoint) -> int:
         return pt.x() if self.orientation() == Qt.Orientation.Horizontal else pt.y()

--- a/src/superqt/sliders/_labeled.py
+++ b/src/superqt/sliders/_labeled.py
@@ -463,7 +463,6 @@ class QLabeledRangeSlider(_SliderProxy, QAbstractSlider):
         self.setLayout(layout)
         layout.setContentsMargins(*marg)
         super().setOrientation(orientation)
-        # QApplication.processEvents()
         self._reposition_labels()
 
     def setInvertedAppearance(self, a0: bool) -> None:

--- a/src/superqt/sliders/_labeled.py
+++ b/src/superqt/sliders/_labeled.py
@@ -9,7 +9,6 @@ from qtpy.QtCore import QPoint, QSize, Qt, Signal
 from qtpy.QtGui import QFontMetrics, QValidator
 from qtpy.QtWidgets import (
     QAbstractSlider,
-    QApplication,
     QBoxLayout,
     QDoubleSpinBox,
     QHBoxLayout,
@@ -257,8 +256,6 @@ class QLabeledSlider(_SliderProxy, QAbstractSlider):
             self.layout().setContentsMargins(0, 0, 0, 0)
         self._on_slider_range_changed(self.minimum(), self.maximum())
 
-        QApplication.processEvents()
-
     # putting this after labelMode methods for the sake of mypy
     EdgeLabelMode = EdgeLabelMode
 
@@ -415,7 +412,6 @@ class QLabeledRangeSlider(_SliderProxy, QAbstractSlider):
         elif opt == EdgeLabelMode.LabelIsRange:
             self._min_label.setValue(self._slider.minimum())
             self._max_label.setValue(self._slider.maximum())
-        QApplication.processEvents()
         self._reposition_labels()
 
     def setRange(self, min: int, max: int) -> None:
@@ -465,7 +461,6 @@ class QLabeledRangeSlider(_SliderProxy, QAbstractSlider):
         self.setLayout(layout)
         layout.setContentsMargins(*marg)
         super().setOrientation(orientation)
-        QApplication.processEvents()
         self._reposition_labels()
 
     def setInvertedAppearance(self, a0: bool) -> None:

--- a/src/superqt/sliders/_range_style.py
+++ b/src/superqt/sliders/_range_style.py
@@ -5,7 +5,6 @@ import re
 from dataclasses import dataclass, replace
 from typing import TYPE_CHECKING
 
-from qtpy import QT_VERSION
 from qtpy.QtCore import Qt
 from qtpy.QtGui import (
     QBrush,
@@ -140,8 +139,9 @@ CATALINA_STYLE = replace(
     tick_offset=4,
 )
 
-if QT_VERSION and int(QT_VERSION.split(".")[0]) == 6:
-    CATALINA_STYLE = replace(CATALINA_STYLE, tick_offset=2)
+# I can no longer reproduce the cases in which this was necessary
+# if QT_VERSION and int(QT_VERSION.split(".")[0]) == 6:
+#     CATALINA_STYLE = replace(CATALINA_STYLE, tick_offset=2)
 
 BIG_SUR_STYLE = replace(
     CATALINA_STYLE,
@@ -155,8 +155,9 @@ BIG_SUR_STYLE = replace(
     tick_bar_alpha=0.2,
 )
 
-if QT_VERSION and int(QT_VERSION.split(".")[0]) == 6:
-    BIG_SUR_STYLE = replace(BIG_SUR_STYLE, tick_offset=-3)
+# I can no longer reproduce the cases in which this was necessary
+# if QT_VERSION and int(QT_VERSION.split(".")[0]) == 6:
+#     BIG_SUR_STYLE = replace(BIG_SUR_STYLE, tick_offset=-3)
 
 WINDOWS_STYLE = replace(
     BASE_STYLE,
@@ -229,7 +230,7 @@ rgba_pattern = re.compile(
 )
 
 
-def parse_color(color: str, default_attr) -> QColor | QGradient:
+def parse_color(color: str, default_attr: str) -> QColor | QGradient:
     qc = QColor(color)
     if qc.isValid():
         return qc
@@ -241,6 +242,7 @@ def parse_color(color: str, default_attr) -> QColor | QGradient:
 
     # try linear gradient:
     match = qlineargrad_pattern.search(color)
+    grad: QGradient
     if match:
         grad = QLinearGradient(*(float(i) for i in match.groups()[:4]))
         grad.setColorAt(0, QColor(match.groupdict()["stop0"]))
@@ -259,11 +261,11 @@ def parse_color(color: str, default_attr) -> QColor | QGradient:
     return QColor(getattr(SYSTEM_STYLE, default_attr))
 
 
-def update_styles_from_stylesheet(obj: _GenericRangeSlider):
+def update_styles_from_stylesheet(obj: _GenericRangeSlider) -> None:
     qss: str = obj.styleSheet()
 
     parent = obj.parent()
-    while parent is not None:
+    while parent and hasattr(parent, "styleSheet"):
         qss = parent.styleSheet() + qss
         parent = parent.parent()
     qss = QApplication.instance().styleSheet() + qss

--- a/src/superqt/utils/_ensure_thread.py
+++ b/src/superqt/utils/_ensure_thread.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from concurrent.futures import Future
+from contextlib import suppress
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Callable, ClassVar, overload
 
@@ -41,7 +42,8 @@ class CallCallable(QObject):
     def call(self):
         CallCallable.instances.remove(self)
         res = self._callable(*self._args, **self._kwargs)
-        self.finished.emit(res)
+        with suppress(RuntimeError):
+            self.finished.emit(res)
 
 
 # fmt: off


### PR DESCRIPTION
This PR fixes a variety of issues I've encountered, mostly with labeled sliders:

- removes calls to `QApplication.processEvents()` in the labeled sliders.  When using this slider in one of my applications, I was observing some very strange behavior.  Gradually, by removing things piece by piece, I was able to narrow it down to these calls to `processEvents()` in the slider.   The calls are there because, without them, if you interactively do something like `.setEdgeLabelMode(wdg.EdgeLabelMode.NoLabel)`, it will leave the handle labels in a slightly odd position, until the next time the widget is updated (which is likely to be very soon, or at least the next time the slider is touched/moved).  I will try to figure out how to fix that moment of unstyled view, but the consequences of calling `processEvents` are probably even worse, and much harder to debug (since it can have a global effect, but no one would know where it's coming from).
- fixes behavior of using the mouse wheel to move a rangeSlider when the two handles are very close to each other (before, this, it would first ensure that the two values were at least 3 apart)
- fixes a ZeroDevisionError that can occasionally happen if the min and max value of a slider are the same thing
- fixes a couple issues with the signals on QLabeledSlider not emitting (i.e. it uses the pattern already being used by the DoubleSlider)
- adds a new `LabelPosition.LabelsOnHandle` enum that results in the labels being placed directly ON a slider handle.  It's not always useful, but it can save space if you're also using a custom stylesheet.
- catches an occasional RuntimeError when emitting the finished signal from `ensure_main_thread`
- fixes the ability to set bar color using QSS on QLabeledRangeSliders
- fixes the slight offset now seen on macos tick sliders