### PR TITLE
perf: improve paint time for QColormapLineEdit

### DIFF
--- a/src/superqt/cmap/_cmap_line_edit.py
+++ b/src/superqt/cmap/_cmap_line_edit.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from qtpy.QtCore import Qt, QRect
+from qtpy.QtCore import QRect, Qt
 from qtpy.QtGui import QIcon, QPainter, QPaintEvent, QPalette
 from qtpy.QtWidgets import QApplication, QLineEdit, QStyle, QWidget
 


### PR DESCRIPTION
small PR that improves the time-to-paint performance of `QColormapLineEdit` (which is used in the cmap combobox).