### PR TITLE
Prevent computing full document content highlight per block and only compute current block content for performance

### DIFF
--- a/src/superqt/utils/_code_syntax_highlight.py
+++ b/src/superqt/utils/_code_syntax_highlight.py
@@ -1,5 +1,3 @@
-from itertools import takewhile
-
 from pygments import highlight
 from pygments.formatter import Formatter
 from pygments.lexers import find_lexer_class, get_lexer_by_name
@@ -68,21 +66,10 @@ class CodeSyntaxHighlight(QtGui.QSyntaxHighlighter):
         return self.formatter.style.background_color
 
     def highlightBlock(self, text):
-        cb = self.currentBlock()
-        p = cb.position()
-        text_ = self.document().toPlainText() + "\n"
-        highlight(text_, self.lexer, self.formatter)
-
-        enters = sum(1 for _ in takewhile(lambda x: x == "\n", text_))
-        # pygments lexer ignore leading empty lines, so we need to do correction
-        # here calculating the number of empty lines.
-
         # dirty, dirty hack
         # The core problem is that pygemnts by default use string streams,
         # that will not handle QTextCharFormat, so we need use `data` property to
         # work around this.
+        highlight(text, self.lexer, self.formatter)
         for i in range(len(text)):
-            try:
-                self.setFormat(i, 1, self.formatter.data[p + i - enters])
-            except IndexError:  # pragma: no cover
-                pass
+            self.setFormat(i, 1, self.formatter.data[i])


### PR DESCRIPTION
Related with https://github.com/napari/napari/issues/6845

Current code computes the full document highlight for each document block/paragraph causing freezes as soon the document content starts to get a little bit long. To reproduce, you can run the `examples/code_highlight.py`, copy and paste the widget text content multiple times (selecting the full content to do a new paste increases the chance to stumble with a freeze in a shorter amount of time). So something like:

![highlight](https://github.com/pyapp-kit/superqt/assets/16781833/16a9660d-f09c-43e8-af64-7a4de9034b38)

This PR tries to prevent/improve the situation by only computing the current block content/text highlight data (not sure if there is a better approach so happy to give a check to any other ideas!). Doing a similar check with the example content copy and paste operations with the changes in this PR:

![highlight_perf](https://github.com/pyapp-kit/superqt/assets/16781833/95245192-7fd6-4152-b072-d9aa1ae2711a)
