### PR TITLE
refactor: remove stylesheet on sliderLabel

### DIFF
--- a/src/superqt/sliders/_labeled.py
+++ b/src/superqt/sliders/_labeled.py
@@ -654,7 +654,14 @@ class SliderLabel(QDoubleSpinBox):
         slider.rangeChanged.connect(self._update_size)
         self.setAlignment(alignment)
         self.setButtonSymbols(QSpinBox.ButtonSymbols.NoButtons)
-        self.setStyleSheet("background:transparent; border: 0;")
+
+        le = self.lineEdit()
+        # make the lineedit transparent
+        palette = le.palette()
+        palette.setColor(palette.ColorRole.Base, Qt.GlobalColor.transparent)
+        le.setPalette(palette)
+        le.setFrame(False)  # no border
+
         if connect is not None:
             self.editingFinished.connect(lambda: connect(self.value()))
         self.editingFinished.connect(self._silent_clear_focus)


### PR DESCRIPTION
makes it easier to override with setylesheets elswhere, like 

```python
app.setStyleSheet("SliderLabel { border: 2px solid black; background-color: lightgray; }")
```