### PR TITLE
Fix KeyError in CodeSyntaxHighlight

### DIFF
--- a/src/superqt/utils/_code_syntax_highlight.py
+++ b/src/superqt/utils/_code_syntax_highlight.py
@@ -36,7 +36,7 @@ def get_text_char_format(style):
 class QFormatter(Formatter):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
-        self.data = []
+        self.data: list[QtGui.QTextCharFormat] = []
         self._style = {name: get_text_char_format(style) for name, style in self.style}
 
     def format(self, tokensource, outfile):
@@ -49,7 +49,9 @@ class QFormatter(Formatter):
         self.data = []
 
         for token, value in tokensource:
-            self.data.extend([self._style[token]] * len(value))
+            self.data.extend(
+                [self._style.get(token, QtGui.QTextCharFormat())] * len(value)
+            )
 
 
 class CodeSyntaxHighlight(QtGui.QSyntaxHighlighter):

--- a/src/superqt/utils/_code_syntax_highlight.py
+++ b/src/superqt/utils/_code_syntax_highlight.py
@@ -9,7 +9,9 @@ from qtpy import QtGui
 # https://pygments.org/docs/formatterdevelopment/#html-3-2-formatter
 
 
-def get_text_char_format(style):
+def get_text_char_format(
+    style: dict[str, QtGui.QTextCharFormat],
+) -> QtGui.QTextCharFormat:
     text_char_format = QtGui.QTextCharFormat()
     if hasattr(text_char_format, "setFontFamilies"):
         text_char_format.setFontFamilies(["monospace"])

--- a/src/superqt/utils/_code_syntax_highlight.py
+++ b/src/superqt/utils/_code_syntax_highlight.py
@@ -51,6 +51,8 @@ class QFormatter(Formatter):
         self.data = []
 
         for token, value in tokensource:
+            # using get method to workaround not defined style for plain token
+            # https://github.com/pygments/pygments/issues/2149
             self.data.extend(
                 [self._style.get(token, QtGui.QTextCharFormat())] * len(value)
             )


### PR DESCRIPTION
I noticed that `CodeSyntaxHighlight` sometimes fails to highlight the texts. This PR fixes the KeyError just by replacing the `__getitem__` with `get`. I encountered this bug when I tried to highlight my pre-commit-config.yaml file, so I cannot tell when this happens.

```python
from superqt.utils import CodeSyntaxHighlight
from qtpy import QtWidgets as QtW

w = QtW.QPlainTextEdit()
highlight = CodeSyntaxHighlight(w.document(), "yaml", "default")
w.setPlainText("ci:\n  autoupdate_schedule: monthly")
```

Output:

```
KeyError                                  Traceback (most recent call last)
File ~\Desktop\code\python\superqt\src\superqt\utils\_code_syntax_highlight.py:73, in CodeSyntaxHighlight.highlightBlock(self, text)
     68 def highlightBlock(self, text):
     69     # dirty, dirty hack
     70     # The core problem is that pygemnts by default use string streams,
     71     # that will not handle QTextCharFormat, so we need use `data` property to
     72     # work around this.
---> 73     highlight(text, self.lexer, self.formatter)
     74     for i in range(len(text)):
     75         self.setFormat(i, 1, self.formatter.data[i])

File ~\mambaforge\envs\mt\Lib\site-packages\pygments\__init__.py:82, in highlight(code, lexer, formatter, outfile)
     77 def highlight(code, lexer, formatter, outfile=None):
     78     """
     79     This is the most high-level highlighting function. It combines `lex` and
     80     `format` in one function.
     81     """
---> 82     return format(lex(code, lexer), formatter, outfile)

File ~\mambaforge\envs\mt\Lib\site-packages\pygments\__init__.py:64, in format(tokens, formatter, outfile)
     62 if not outfile:
     63     realoutfile = getattr(formatter, 'encoding', None) and BytesIO() or StringIO()
---> 64     formatter.format(tokens, realoutfile)
     65     return realoutfile.getvalue()
     66 else:

File ~\Desktop\code\python\superqt\src\superqt\utils\_code_syntax_highlight.py:52, in QFormatter.format(self, tokensource, outfile)
     49 self.data = []
     51 for token, value in tokensource:
---> 52     self.data.extend([self._style[token]] * len(value))

KeyError: Token.Literal.Scalar.Plain
```