### PR TITLE
Lazy-import `pyconify`

### DIFF
--- a/src/superqt/__init__.py
+++ b/src/superqt/__init__.py
@@ -11,7 +11,6 @@ except PackageNotFoundError:
 from .collapsible import QCollapsible
 from .combobox import QColorComboBox, QEnumComboBox, QSearchableComboBox
 from .elidable import QElidingLabel, QElidingLineEdit
-from .iconify import QIconifyIcon
 from .selection import QSearchableListWidget, QSearchableTreeWidget
 from .sliders import (
     QDoubleRangeSlider,
@@ -58,16 +57,21 @@ __all__ = [
 
 if TYPE_CHECKING:
     from .combobox import QColormapComboBox  # noqa: TC004
+    from .iconify import QIconifyIcon  # noqa: TC004
     from .spinbox._quantity import QQuantity  # noqa: TC004
 
 
 def __getattr__(name: str) -> Any:
-    if name == "QQuantity":
-        from .spinbox._quantity import QQuantity
-
-        return QQuantity
     if name == "QColormapComboBox":
         from .cmap import QColormapComboBox
 
         return QColormapComboBox
+    if name == "QIconifyIcon":
+        from .iconify import QIconifyIcon
+
+        return QIconifyIcon
+    if name == "QQuantity":
+        from .spinbox._quantity import QQuantity
+
+        return QQuantity
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/src/superqt/iconify/__init__.py
+++ b/src/superqt/iconify/__init__.py
@@ -7,11 +7,22 @@ from qtpy.QtCore import QSize, Qt
 from qtpy.QtGui import QIcon, QPainter, QPixmap
 from qtpy.QtWidgets import QApplication
 
+try:
+    from pyconify import svg_path
+except ModuleNotFoundError:  # pragma: no cover
+    raise ModuleNotFoundError(
+        "pyconify is required to use QIconifyIcon. "
+        "Please install it with `pip install pyconify` or use the "
+        "`pip install superqt[iconify]` extra."
+    ) from None
+
 if TYPE_CHECKING:
     from typing import Literal
 
     Flip = Literal["horizontal", "vertical", "horizontal,vertical"]
     Rotation = Literal["90", "180", "270", 90, 180, 270, "-90", 1, 2, 3]
+
+__all__ = ["QIconifyIcon"]
 
 
 class QIconifyIcon(QIcon):
@@ -69,14 +80,6 @@ class QIconifyIcon(QIcon):
         rotate: Rotation | None = None,
         dir: str | None = None,
     ):
-        try:
-            import pyconify  # noqa: F401
-        except ModuleNotFoundError:  # pragma: no cover
-            raise ModuleNotFoundError(
-                "pyconify is required to use QIconifyIcon. "
-                "Please install it with `pip install pyconify` or use the "
-                "`pip install superqt[iconify]` extra."
-            ) from None
         super().__init__()
         if key:
             self.addKey(*key, color=color, flip=flip, rotate=rotate, dir=dir)
@@ -127,8 +130,6 @@ class QIconifyIcon(QIcon):
         QIconifyIcon
             This QIconifyIcon instance, for chaining.
         """
-        from pyconify import svg_path
-
         try:
             path = svg_path(*key, color=color, flip=flip, rotate=rotate, dir=dir)
         except OSError as e:

--- a/src/superqt/iconify/__init__.py
+++ b/src/superqt/iconify/__init__.py
@@ -13,11 +13,6 @@ if TYPE_CHECKING:
     Flip = Literal["horizontal", "vertical", "horizontal,vertical"]
     Rotation = Literal["90", "180", "270", 90, 180, 270, "-90", 1, 2, 3]
 
-try:
-    from pyconify import svg_path
-except ModuleNotFoundError:  # pragma: no cover
-    svg_path = None
-
 
 class QIconifyIcon(QIcon):
     """QIcon backed by an iconify icon.
@@ -74,12 +69,14 @@ class QIconifyIcon(QIcon):
         rotate: Rotation | None = None,
         dir: str | None = None,
     ):
-        if svg_path is None:  # pragma: no cover
+        try:
+            import pyconify  # noqa: F401
+        except ModuleNotFoundError:  # pragma: no cover
             raise ModuleNotFoundError(
                 "pyconify is required to use QIconifyIcon. "
                 "Please install it with `pip install pyconify` or use the "
                 "`pip install superqt[iconify]` extra."
-            )
+            ) from None
         super().__init__()
         if key:
             self.addKey(*key, color=color, flip=flip, rotate=rotate, dir=dir)
@@ -130,6 +127,8 @@ class QIconifyIcon(QIcon):
         QIconifyIcon
             This QIconifyIcon instance, for chaining.
         """
+        from pyconify import svg_path
+
         try:
             path = svg_path(*key, color=color, flip=flip, rotate=rotate, dir=dir)
         except OSError as e:


### PR DESCRIPTION
I found that ~50% of the import time of `superqt` originates from `pyconify` even though only `QIconifyIcon` depends on it.
This PR moves the import statements inside the methods.

In my local environment, the execution time of `import superqt` was:
main: 0.864 s (pyconify: 0.445 s)
this PR: 0.436 s