### PR TITLE
test: Don't test napari main

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -87,6 +87,22 @@ jobs:
     uses: pyapp-kit/workflows/.github/workflows/upload-coverage.yml@v2
     secrets: inherit
 
+  test_napari:
+    uses: pyapp-kit/workflows/.github/workflows/test-dependents.yml@v2
+    with:
+      dependency-repo: napari/napari
+      dependency-ref: ${{ matrix.napari-version }}
+      dependency-extras: "testing"
+      qt: ${{ matrix.qt }}
+      pytest-args: 'napari/_qt -k "not async and not qt_dims_2 and not qt_viewer_console_focus and not keybinding_editor and not preferences_dialog_not_dismissed"'
+      python-version: "3.10"
+      post-install-cmd: "pip install lxml_html_clean"
+    strategy:
+      fail-fast: false
+      matrix:
+        napari-version: ["v0.5.6", "v0.4.19.post1"]
+        qt: ["pyqt5", "pyside2"]
+
   check-manifest:
     name: Check Manifest
     runs-on: ubuntu-latest

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -87,22 +87,6 @@ jobs:
     uses: pyapp-kit/workflows/.github/workflows/upload-coverage.yml@v2
     secrets: inherit
 
-  test_napari:
-    uses: pyapp-kit/workflows/.github/workflows/test-dependents.yml@v2
-    with:
-      dependency-repo: napari/napari
-      dependency-ref: ${{ matrix.napari-version }}
-      dependency-extras: "testing"
-      qt: ${{ matrix.qt }}
-      pytest-args: 'napari/_qt -k "not async and not qt_dims_2 and not qt_viewer_console_focus and not keybinding_editor and not preferences_dialog_not_dismissed"'
-      python-version: "3.10"
-      post-install-cmd: "pip install lxml_html_clean"
-    strategy:
-      fail-fast: false
-      matrix:
-        napari-version: ["", "v0.4.19.post1"]
-        qt: ["pyqt5", "pyside2"]
-
   check-manifest:
     name: Check Manifest
     runs-on: ubuntu-latest


### PR DESCRIPTION
I'm afraid it's a bit too hard to maintain running tests against napari `main` on each PR.  napari certainly needs to be able to be flexible in writing its own tests, but unfortunately it too often breaks here.  this PR no longer tests against napari main, but does still test against an old version (v0.4.19.post1) and a new version (v0.5.6)