### PR TITLE
Fix themes compatibility for QRangeSlider

### DIFF
--- a/docs/widgets/qrangeslider.md
+++ b/docs/widgets/qrangeslider.md
@@ -227,3 +227,31 @@ setSliderPosition(val: Sequence[int]) -> None
 ```python
 sliderMoved(Tuple[int, ...])
 ```
+
+## Custom Styles for Compatibility with qdarkstyle
+
+To ensure compatibility with qdarkstyle, you can add custom styles for `QRangeSlider` as shown below:
+
+```python
+QSS = """
+QSlider {
+    background-color: none;
+}
+
+QSlider::add-page:vertical {
+    background: none;
+    border: none;
+}
+
+QRangeSlider {
+    qproperty-barColor: #9FCBFF;
+}
+"""
+```
+
+You can then set the stylesheet for your `QRangeSlider` instance:
+
+```python
+slider = QRangeSlider(Qt.Orientation.Horizontal)
+slider.setStyleSheet(QSS)
+```

--- a/src/superqt/sliders/_generic_range_slider.py
+++ b/src/superqt/sliders/_generic_range_slider.py
@@ -165,7 +165,21 @@ class _GenericRangeSlider(_GenericSlider):
         self._doSliderMove()
 
     def setStyleSheet(self, styleSheet: str) -> None:
-        return super().setStyleSheet(self._patch_style(styleSheet))
+        custom_styles = """
+        QSlider{
+            background-color: none;
+        }
+
+        QSlider::add-page:vertical {
+            background: none;
+            border: none;
+        }
+
+        QRangeSlider {
+            qproperty-barColor: #9FCBFF;
+        }
+        """
+        return super().setStyleSheet(self._patch_style(styleSheet + custom_styles))
 
     def _patch_style(self, style: str):
         """Override to patch style options before painting."""

--- a/src/superqt/sliders/_range_style.py
+++ b/src/superqt/sliders/_range_style.py
@@ -300,7 +300,7 @@ def update_styles_from_stylesheet(obj: _GenericRangeSlider) -> None:
         for line in reversed(match.groups()[0].splitlines()):
             bgrd = re.search(r"qproperty-barColor\s*:\s*(.+);", line)
             if bgrd:
-                obj.setBarColor(bgrd.groups()[-1])
+                obj._setBarColor(bgrd.groups()[-1])
                 obj._style.has_stylesheet = True
 
 

--- a/src/superqt/sliders/_range_style.py
+++ b/src/superqt/sliders/_range_style.py
@@ -68,7 +68,13 @@ class RangeSliderStyle:
             val = _val
 
         if opt.tickPosition != QSlider.TickPosition.NoTicks:
-            val.setAlphaF(self.tick_bar_alpha or SYSTEM_STYLE.tick_bar_alpha)
+            if isinstance(val, QColor):
+                val.setAlphaF(self.tick_bar_alpha or SYSTEM_STYLE.tick_bar_alpha)
+            elif isinstance(val, QGradient):
+                for i in range(val.colorCount()):
+                    color = val.colorAt(i)
+                    color.setAlphaF(self.tick_bar_alpha or SYSTEM_STYLE.tick_bar_alpha)
+                    val.setColorAt(i, color)
 
         return QBrush(val)
 

--- a/src/superqt/sliders/_range_style.py
+++ b/src/superqt/sliders/_range_style.py
@@ -288,6 +288,15 @@ def update_styles_from_stylesheet(obj: _GenericRangeSlider) -> None:
                     setattr(obj._style, f"{orient}_thickness", thickness)
                     obj._style.has_stylesheet = True
 
+    # Find bar color
+    match = re.search(r"QRangeSlider\s*{\s*([^}]+)}", qss, re.S)
+    if match:
+        for line in reversed(match.groups()[0].splitlines()):
+            bgrd = re.search(r"qproperty-barColor\s*:\s*(.+);", line)
+            if bgrd:
+                obj.setBarColor(bgrd.groups()[-1])
+                obj._style.has_stylesheet = True
+
 
 # a fix for https://bugreports.qt.io/browse/QTBUG-98093
 


### PR DESCRIPTION
Add custom styles for `QRangeSlider` to ensure compatibility with qdarkstyle.

* Update the `setStyleSheet` method in `src/superqt/sliders/_generic_range_slider.py` to include the custom styles for qdarkstyle.
* Update the `update_styles_from_stylesheet` function in `src/superqt/sliders/_range_style.py` to handle stylesheets more effectively.
* Add documentation in `docs/widgets/qrangeslider.md` to guide users on how to apply custom styles for compatibility with qdarkstyle. 

