### PR TITLE
Make qimage_to_array() work on big endian

### DIFF
--- a/src/superqt/utils/_img_utils.py
+++ b/src/superqt/utils/_img_utils.py
@@ -1,3 +1,5 @@
+import sys
+
 from typing import TYPE_CHECKING
 
 from qtpy.QtGui import QImage
@@ -37,4 +39,8 @@ def qimage_to_array(img: QImage) -> "np.ndarray":
     arr = np.frombuffer(b, np.uint8).reshape(h, w, c)
 
     # reverse channel colors for numpy
-    return arr.take([2, 1, 0, 3], axis=2)
+    # On big endian we need to specify a different order
+    if sys.byteorder == 'big':
+        return arr.take([1, 2, 3, 0], axis=2)
+    else:
+        return arr.take([2, 1, 0, 3], axis=2)

--- a/src/superqt/utils/_img_utils.py
+++ b/src/superqt/utils/_img_utils.py
@@ -1,5 +1,4 @@
 import sys
-
 from typing import TYPE_CHECKING
 
 from qtpy.QtGui import QImage
@@ -40,7 +39,7 @@ def qimage_to_array(img: QImage) -> "np.ndarray":
 
     # reverse channel colors for numpy
     # On big endian we need to specify a different order
-    if sys.byteorder == 'big':
+    if sys.byteorder == "big":
         return arr.take([1, 2, 3, 0], axis=2)
     else:
         return arr.take([2, 1, 0, 3], axis=2)

--- a/src/superqt/utils/_img_utils.py
+++ b/src/superqt/utils/_img_utils.py
@@ -40,6 +40,6 @@ def qimage_to_array(img: QImage) -> "np.ndarray":
     # reverse channel colors for numpy
     # On big endian we need to specify a different order
     if sys.byteorder == "big":
-        return arr.take([1, 2, 3, 0], axis=2)
+        return arr.take([1, 2, 3, 0], axis=2)  # pragma: no cover
     else:
         return arr.take([2, 1, 0, 3], axis=2)


### PR DESCRIPTION
Make sure the returned ndarray is ordered the same as on little
endian systems.

Solves #287
