### PR TITLE
fix: Set SliderProxy range params to Any

### DIFF
--- a/src/superqt/sliders/_labeled.py
+++ b/src/superqt/sliders/_labeled.py
@@ -83,7 +83,7 @@ class _SliderProxy:
     def setPageStep(self, step: int) -> None:
         self._slider.setPageStep(step)
 
-    def setRange(self, min: int, max: int) -> None:
+    def setRange(self, min: Any, max: Any) -> None:
         self._slider.setRange(min, max)
 
     def tickInterval(self) -> int:


### PR DESCRIPTION
When the types are `int`s, this raises mypy errors when e.g. setting the range of a `QDoubleSlider` to float values.

This change aligns with the parameter typing of `_SliderProxy.setValue`