### PR TITLE
fix: Fix size of Slider label to not ocupy to much space

### DIFF
--- a/src/superqt/sliders/_labeled.py
+++ b/src/superqt/sliders/_labeled.py
@@ -6,11 +6,7 @@ from typing import TYPE_CHECKING, Any, overload
 
 from qtpy import QtGui
 from qtpy.QtCore import Property, QPoint, QSize, Qt, Signal
-from qtpy.QtGui import (
-    QDoubleValidator,
-    QFontMetrics,
-    QValidator,
-)
+from qtpy.QtGui import QDoubleValidator, QFontMetrics, QValidator
 from qtpy.QtWidgets import (
     QAbstractSlider,
     QBoxLayout,


### PR DESCRIPTION
Follow up to #226. 
Solves problem pointed out by @psobolewskiPhD  https://github.com/napari/napari/pull/8184#issuecomment-3141341450

I found that, even if parent is set, the qss rules are not applied. 

I found that recalculation of size may be triggered on showEvent. 

Other option is to check for `StyleChange` event in `changeEvent` method