### PR TITLE
chore: Group dependabot updates in a single PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "ci(dependabot):"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
To avoid the creation of multiple PR with updates of actions, just configure dependabot to open a single PR. 