### PR TITLE
Update qt beckends that superqt is tested against with napari

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -113,12 +113,11 @@ jobs:
       qt: ${{ matrix.qt }}
       pytest-args: 'src/napari/_qt --import-mode=importlib -k "not async and not qt_dims_2 and not qt_viewer_console_focus and not keybinding_editor and not preferences_dialog_not_dismissed"'
       python-version: "3.10"
-      # napari hasn't pinned pytest-qt, but still requires pyside2 tests
-      post-install-cmd: "pip install lxml_html_clean pytest-qt==4.4.0"
+      post-install-cmd: "pip install lxml_html_clean"
     strategy:
       fail-fast: false
       matrix:
-        qt: ["pyqt5", "pyside2"]
+        qt: ["pyqt5", "pyqt6", "pyside6"]
 
   check-manifest:
     name: Check Manifest


### PR DESCRIPTION
Napari dropped support for PySide2, so tests against this backend will fail. 