### PR TITLE
fix: Use faint color for disabled on-state toggle switch

### DIFF
--- a/src/superqt/switch/_toggle_switch.py
+++ b/src/superqt/switch/_toggle_switch.py
@@ -139,12 +139,23 @@ class QToggleSwitch(QtW.QAbstractButton):
         is_checked = option.state & QtW.QStyle.StateFlag.State_On
         is_enabled = option.state & QtW.QStyle.StateFlag.State_Enabled
         # draw the groove
+        on_color = option.on_color
+        off_color = option.off_color
         if is_enabled:
-            painter.setBrush(option.on_color if is_checked else option.off_color)
+            painter.setBrush(on_color if is_checked else off_color)
             painter.setRenderHint(QtGui.QPainter.RenderHint.Antialiasing, True)
             painter.setOpacity(0.8)
         else:
-            painter.setBrush(option.off_color)
+            if is_checked:
+                ratio = 0.32
+                mixed_color = QtGui.QColor(
+                    int(on_color.red() * ratio + off_color.red() * (1 - ratio)),
+                    int(on_color.green() * ratio + off_color.green() * (1 - ratio)),
+                    int(on_color.blue() * ratio + off_color.blue() * (1 - ratio)),
+                )
+                painter.setBrush(mixed_color)
+            else:
+                painter.setBrush(off_color)
             painter.setOpacity(0.6)
 
         half_height = option.switch_height / 2

--- a/tests/test_toggle_switch.py
+++ b/tests/test_toggle_switch.py
@@ -1,9 +1,24 @@
 from unittest.mock import Mock
 
+import pytest
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import QApplication, QCheckBox, QVBoxLayout, QWidget
 
 from superqt import QToggleSwitch
+
+
+def test_construction(qtbot):
+    wdg = QToggleSwitch("test")
+    qtbot.addWidget(wdg)
+    assert wdg.text() == "test"
+
+    parent = QWidget()
+    qtbot.addWidget(parent)
+    wdg = QToggleSwitch(parent)
+    assert wdg.parent() is parent
+
+    with pytest.raises(TypeError):
+        QToggleSwitch(parent, "test")
 
 
 def test_on_and_off(qtbot):
@@ -28,6 +43,19 @@ def test_on_and_off(qtbot):
     wdg.click()
     assert not wdg.isChecked()
     QApplication.processEvents()
+
+
+def test_disabled(qtbot):
+    wdg = QToggleSwitch()
+    qtbot.addWidget(wdg)
+    wdg.setDisabled(True)
+    assert not wdg.isEnabled()
+    initial_state = wdg.isChecked()
+    qtbot.mouseClick(wdg, Qt.MouseButton.LeftButton)
+    assert wdg.isChecked() == initial_state  # state should not change
+    wdg.setChecked(not initial_state)
+    qtbot.mouseClick(wdg, Qt.MouseButton.LeftButton)
+    assert wdg.isChecked() == (not initial_state)  # state should not change
 
 
 def test_get_set(qtbot):


### PR DESCRIPTION
In the current implementation, we use the same toggle swtich groove color for enabled+off, disabled+on and disabled+off. This makes the check state unclear when the widget is disabled.

In this PR, on-color and off-color are mixed so it is visually easier to find the on-state switches, and they do not stand out too much. 

Examples of enabled vs disabled toggle switches:

<img width="320" height="157" alt="image" src="https://github.com/user-attachments/assets/a9ab9d35-33f0-463a-a1aa-c43bb2064972" />

