### PR TITLE
refactor: use style-sheet free QToolButton for QCollapsible

### DIFF
--- a/src/superqt/collapsible/_collapsible.py
+++ b/src/superqt/collapsible/_collapsible.py
@@ -15,6 +15,7 @@ from qtpy.QtCore import (
 )
 from qtpy.QtGui import QIcon, QPainter, QPaintEvent, QPalette, QPixmap
 from qtpy.QtWidgets import (
+    QApplication,
     QFrame,
     QSizePolicy,
     QStyle,
@@ -33,6 +34,8 @@ class _GhostToolButton(QToolButton):
         super().__init__(parent)
         if title:
             self.setText(title)
+        # Match QPushButton typography from main for consistent header text size.
+        self.setFont(QApplication.font("QPushButton"))
         self.setCheckable(True)
         self.setAutoRaise(True)
         self.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)

--- a/src/superqt/collapsible/_collapsible.py
+++ b/src/superqt/collapsible/_collapsible.py
@@ -13,8 +13,39 @@ from qtpy.QtCore import (
     Qt,
     Signal,
 )
-from qtpy.QtGui import QIcon, QPainter, QPalette, QPixmap
-from qtpy.QtWidgets import QFrame, QPushButton, QSizePolicy, QVBoxLayout, QWidget
+from qtpy.QtGui import QIcon, QPainter, QPaintEvent, QPalette, QPixmap
+from qtpy.QtWidgets import (
+    QFrame,
+    QSizePolicy,
+    QStyle,
+    QStyleOptionToolButton,
+    QStylePainter,
+    QToolButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+
+class _GhostToolButton(QToolButton):
+    """Tool button that keeps a ghost appearance while checked."""
+
+    def __init__(self, parent: QWidget | None = None, *, title: str = "") -> None:
+        super().__init__(parent)
+        if title:
+            self.setText(title)
+        self.setCheckable(True)
+        self.setAutoRaise(True)
+        self.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
+        self.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
+
+    def paintEvent(self, a0: QPaintEvent | None) -> None:
+        if not a0:
+            return super().paintEvent(a0)
+        option = QStyleOptionToolButton()
+        self.initStyleOption(option)
+        option.state &= ~QStyle.StateFlag.State_On
+        painter = QStylePainter(self)
+        painter.drawControl(QStyle.ControlElement.CE_ToolButtonLabel, option)
 
 
 class QCollapsible(QFrame):
@@ -39,13 +70,11 @@ class QCollapsible(QFrame):
         self._is_animating = False
         self._text = title
 
-        self._toggle_btn = QPushButton(title)
-        self._toggle_btn.setCheckable(True)
+        self._toggle_btn = _GhostToolButton(self, title=title)
         self.setCollapsedIcon(icon=collapsedIcon)
         self.setExpandedIcon(icon=expandedIcon)
         self.setSizePolicy(QSizePolicy.Policy.Preferred, QSizePolicy.Policy.Maximum)
 
-        self._toggle_btn.setStyleSheet("text-align: left; border: none; outline: none;")
         self._toggle_btn.toggled.connect(self._toggle)
 
         # frame layout
@@ -68,7 +97,7 @@ class QCollapsible(QFrame):
         _content.layout().setContentsMargins(QMargins(5, 0, 0, 0))
         self.setContent(_content)
 
-    def toggleButton(self) -> QPushButton:
+    def toggleButton(self) -> QToolButton:
         """Return the toggle button."""
         return self._toggle_btn
 

--- a/src/superqt/collapsible/_collapsible.py
+++ b/src/superqt/collapsible/_collapsible.py
@@ -36,7 +36,6 @@ class _GhostToolButton(QToolButton):
         self.setCheckable(True)
         self.setAutoRaise(True)
         self.setToolButtonStyle(Qt.ToolButtonStyle.ToolButtonTextBesideIcon)
-        self.setSizePolicy(QSizePolicy.Policy.Fixed, QSizePolicy.Policy.Fixed)
 
     def paintEvent(self, a0: QPaintEvent | None) -> None:
         if not a0:


### PR DESCRIPTION
This removes the hard-coded (fragile, non-theme-aware) stylesheet from the QCollapsible.  It shouldn't change the default style for most use cases and applications (unless those applications are already manually styling all widgets, in which case things *may* change), but it "plays better" with the existing app.

@Czaki @jni @DragaDoncila ... the *one* place you will notice this in napari is in the napari-plugin-manager, which uses this.

currently for you, it looks like this:

<img width="278" height="250" alt="Screenshot 2026-03-29 at 12 23 43 PM" src="https://github.com/user-attachments/assets/b242b59f-4ece-42e0-869d-987337d995a0" />

the toggle button *has* a background.  (That's actually a bit of an "accident" anyway, because `superqt.QCollapsible` attempted to render as background-free with a stylesheet of:

```python
self._toggle_btn.setStyleSheet("text-align: left; border: none; outline: none;")
```

so I think the fact that you see a background is due to your global application stylesheet applying a background to all QPushButtons, somehow overriding the superqt one here (or else, it's being done by the napari-plugin-manager styles somewhere).

With this PR, your plugin manager will look like this:

<img width="300" height="280" alt="Screenshot 2026-03-29 at 12 22 52 PM" src="https://github.com/user-attachments/assets/d35e5243-3df8-4a73-a46b-47d090dfc4c4" />

... and that's because this PR changes it from a QPushButton to a QToolButton (to be able to use `setAutoRaise(True)`... to make it look like a ghost button, which was the original intention of the `border: none; outline: none;` stylesheet hack that was previously applied.

Can you guys live with that change?  Or, if not, update your stylesheets to change it how you want it to appear?