### PR TITLE
fix: Sync the toggle switch state when `setChecked()` is run inside a `QSignalBlocker` 

### DIFF
--- a/src/superqt/switch/_toggle_switch.py
+++ b/src/superqt/switch/_toggle_switch.py
@@ -115,7 +115,7 @@ class QToggleSwitch(QtW.QAbstractButton):
         width = opt.switch_width + text_size.width() + opt.margin * 2 + 8
         return QtCore.QSize(width, height)
 
-    # This fixes the animation when QSignalBlocker is used. It is hacky.
+    # This fixes the animation when QSignalBlocker is used.
     def checkStateSet(self) -> None:
         """Do animation if signals are blocked."""
         super().checkStateSet()

--- a/src/superqt/switch/_toggle_switch.py
+++ b/src/superqt/switch/_toggle_switch.py
@@ -51,7 +51,6 @@ class QToggleSwitch(QtW.QAbstractButton):
         super().__init__(parent)
         self.setCheckable(True)
         self.setCursor(Qt.CursorShape.PointingHandCursor)
-        self.toggled.connect(self._animate_handle)
 
         self._anim = QtCore.QPropertyAnimation(self, b"_offset", self)
         self._anim.setDuration(120)
@@ -115,14 +114,15 @@ class QToggleSwitch(QtW.QAbstractButton):
         width = opt.switch_width + text_size.width() + opt.margin * 2 + 8
         return QtCore.QSize(width, height)
 
-    # This keeps the handle state in sync when setChecked() is called
-    # within a signal blocker
     def checkStateSet(self) -> None:
-        """Sync the handle position when checked state changes under blocked signals."""
+        """Update the handle when the checked state changes programmatically."""
         super().checkStateSet()
-        if self.signalsBlocked():
-            self._anim.stop()
-            self._animate_handle(self.isChecked())
+        self._sync_handle_position()
+
+    def nextCheckState(self) -> None:
+        """Update the handle when the user toggles the button."""
+        super().nextCheckState()
+        self._sync_handle_position()
 
     ### Re-implementable methods for drawing the switch ###
 
@@ -283,10 +283,14 @@ class QToggleSwitch(QtW.QAbstractButton):
 
     ### Other private methods ###
 
+    def _sync_handle_position(self) -> None:
+        self._anim.stop()
+        self._animate_handle(self.isChecked())
+
     def _animate_handle(self, val: bool) -> None:
         end = self._offset_for_checkstate(val)
         if self._anim.duration():
-            self._anim.setStartValue(self._offset_for_checkstate(not val))
+            self._anim.setStartValue(self._offset_value)
             self._anim.setEndValue(end)
             self._anim.start()
         else:

--- a/src/superqt/switch/_toggle_switch.py
+++ b/src/superqt/switch/_toggle_switch.py
@@ -115,6 +115,14 @@ class QToggleSwitch(QtW.QAbstractButton):
         width = opt.switch_width + text_size.width() + opt.margin * 2 + 8
         return QtCore.QSize(width, height)
 
+    # This fixes the animation when QSignalBlocker is used. It is hacky.
+    def checkStateSet(self) -> None:
+        """Do animation if signals are blocked."""
+        super().checkStateSet()
+        if self.signalsBlocked():
+            self._anim.stop()
+            self._animate_handle(self.isChecked())
+
     ### Re-implementable methods for drawing the switch ###
 
     def drawGroove(

--- a/src/superqt/switch/_toggle_switch.py
+++ b/src/superqt/switch/_toggle_switch.py
@@ -115,9 +115,10 @@ class QToggleSwitch(QtW.QAbstractButton):
         width = opt.switch_width + text_size.width() + opt.margin * 2 + 8
         return QtCore.QSize(width, height)
 
-    # This fixes the animation when QSignalBlocker is used.
+    # This keeps the handle state in sync when setChecked() is called
+    # within a signal blocker
     def checkStateSet(self) -> None:
-        """Do animation if signals are blocked."""
+        """Sync the handle position when checked state changes under blocked signals."""
         super().checkStateSet()
         if self.signalsBlocked():
             self._anim.stop()

--- a/tests/test_toggle_switch.py
+++ b/tests/test_toggle_switch.py
@@ -148,6 +148,7 @@ def test_qsignalblocker_updates_handle_position(qtbot):
     wdg = QToggleSwitch()
     qtbot.addWidget(wdg)
     wdg.show()
+    wdg.setAnimationDuration(0)
 
     off = wdg._offset_for_checkstate(False)
     on = wdg._offset_for_checkstate(True)

--- a/tests/test_toggle_switch.py
+++ b/tests/test_toggle_switch.py
@@ -144,7 +144,7 @@ def test_multiple_lines(qtbot):
     assert wdg1.height() > checkbox.height()
 
 
-def test_qsignalblocker_updates_handle_position(qtbot):
+def test_programmatic_state_changes_update_handle_position(qtbot):
     wdg = QToggleSwitch()
     qtbot.addWidget(wdg)
     wdg.show()
@@ -156,6 +156,14 @@ def test_qsignalblocker_updates_handle_position(qtbot):
     assert wdg._offset == off
     assert not wdg.isChecked()
 
+    wdg.setChecked(True)
+    assert wdg.isChecked()
+    assert wdg._offset == on
+
+    wdg.setChecked(False)
+    assert not wdg.isChecked()
+    assert wdg._offset == off
+
     with QSignalBlocker(wdg):
         wdg.setChecked(True)
 
@@ -164,6 +172,29 @@ def test_qsignalblocker_updates_handle_position(qtbot):
 
     with QSignalBlocker(wdg):
         wdg.setChecked(False)
+
+    assert not wdg.isChecked()
+    assert wdg._offset == off
+
+
+def test_mouse_click_updates_handle_position(qtbot):
+    wdg = QToggleSwitch()
+    qtbot.addWidget(wdg)
+    wdg.show()
+    wdg.setAnimationDuration(0)
+
+    off = wdg._offset_for_checkstate(False)
+    on = wdg._offset_for_checkstate(True)
+
+    assert wdg._offset == off
+    assert not wdg.isChecked()
+
+    qtbot.mouseClick(wdg, Qt.MouseButton.LeftButton)
+
+    assert wdg.isChecked()
+    assert wdg._offset == on
+
+    qtbot.mouseClick(wdg, Qt.MouseButton.LeftButton)
 
     assert not wdg.isChecked()
     assert wdg._offset == off

--- a/tests/test_toggle_switch.py
+++ b/tests/test_toggle_switch.py
@@ -1,7 +1,7 @@
 from unittest.mock import Mock
 
 import pytest
-from qtpy.QtCore import Qt
+from qtpy.QtCore import QSignalBlocker, Qt
 from qtpy.QtWidgets import QApplication, QCheckBox, QVBoxLayout, QWidget
 
 from superqt import QToggleSwitch
@@ -142,3 +142,27 @@ def test_multiple_lines(qtbot):
     assert wdg1.sizeHint().height() > checkbox.sizeHint().height()
     assert wdg0.height() > wdg1.height()
     assert wdg1.height() > checkbox.height()
+
+
+def test_qsignalblocker_updates_handle_position(qtbot):
+    wdg = QToggleSwitch()
+    qtbot.addWidget(wdg)
+    wdg.show()
+
+    off = wdg._offset_for_checkstate(False)
+    on = wdg._offset_for_checkstate(True)
+
+    assert wdg._offset == off
+    assert not wdg.isChecked()
+
+    with QSignalBlocker(wdg):
+        wdg.setChecked(True)
+
+    assert wdg.isChecked()
+    assert wdg._offset == on
+
+    with QSignalBlocker(wdg):
+        wdg.setChecked(False)
+
+    assert not wdg.isChecked()
+    assert wdg._offset == off


### PR DESCRIPTION
## Relevant Issues:
#340 

## Issue solved:
It was not properly syncing before whenever the `setChecked()` method was called within a `QSignalBlocker`. This is creating a bug in `napari-metadata` as shown in #340.

 The current problem is that the animation is connected to the `toggle` event and it will be eaten by the `QSignalBlocker` so the color changes but the animation never runs and thus the handle is de-synced. 
 
 This is the best way I could think of syncing back without a somewhat bigger refactor. 

## Changes:
- Added an override to the `checkStateSet()` function that was not being used in `QToggleSwitch` to sync the state of the `isChecked()` method with the toggle button's handle (In the GUI). 
- Added tests to check if the handle is not synced with the button's state. 

Maybe @tlambert03 or @Czaki have a better solution?