### PR TITLE
fix: disallow QQuantity with derived units

### DIFF
--- a/docs/widgets/qquantity.md
+++ b/docs/widgets/qquantity.md
@@ -30,8 +30,8 @@ app.exec()
 
 !!! note
 
-    `QQuantity` currently support simple units with exponents, e.g., `meters^2` or
-    `1/second`. However, non-simple units, e.g. `meter/second`, `Newton`, etc.,
+    `QQuantity` currently supports simple units with exponents, e.g., `meters^2` or
+    `1/second`. However, compound units, e.g. `meter/second`, `Newton`, etc.,
     are not currently supported.
 
 {{ show_widget(150) }}

--- a/docs/widgets/qquantity.md
+++ b/docs/widgets/qquantity.md
@@ -28,6 +28,12 @@ w.show()
 app.exec()
 ```
 
+!!! note
+
+    `QQuantity` currently support simple units with exponents, e.g., `meters^2` or
+    `1/second`. However, non-simple units, e.g. `meter/second`, `Newton`, etc.,
+    are not currently supported.
+
 {{ show_widget(150) }}
 
 {{ show_members('superqt.QQuantity') }}

--- a/src/superqt/spinbox/_quantity.py
+++ b/src/superqt/spinbox/_quantity.py
@@ -202,7 +202,7 @@ class QQuantity(QWidget):
         """Set the magnitude of the current value."""
         self.setValue(self._ureg.Quantity(magnitude, self._value.units))
 
-    def setUnits(self, units: str | Unit | Quantity) -> None:
+    def setUnits(self, units: str | Unit | Quantity | None) -> None:
         """Set the units of the current value.
 
         If `units` is `None`, will convert to a dimensionless quantity.

--- a/src/superqt/spinbox/_quantity.py
+++ b/src/superqt/spinbox/_quantity.py
@@ -111,10 +111,16 @@ class QQuantity(QWidget):
         return self._ureg
 
     def _get_unit_options(self, units: Unit) -> list[Unit]:
+        if len(units.dimensionality) > 1:
+            raise NotImplementedError(
+                "QQuantity does not currently support quantities with derived units."
+            )
         dims, exp = next(iter(units.dimensionality.items()))
+
+        options = DEFAULT_OPTIONS.get(dims, [])
         if exp != 1:
-            raise NotImplementedError("Inverse units not yet implemented")
-        return [self._ureg.Unit(u) for u in DEFAULT_OPTIONS.get(dims, [])]
+            options = [f"({u})^{exp}" for u in options]
+        return [Unit(u) for u in options]
 
     def _update_units_combo_choices(self):
         if self._value.dimensionless:

--- a/src/superqt/spinbox/_quantity.py
+++ b/src/superqt/spinbox/_quantity.py
@@ -110,6 +110,12 @@ class QQuantity(QWidget):
         """Return the pint UnitRegistry used by this widget."""
         return self._ureg
 
+    def _get_unit_options(self, units: Unit) -> list[Unit]:
+        dims, exp = next(iter(units.dimensionality.items()))
+        if exp != 1:
+            raise NotImplementedError("Inverse units not yet implemented")
+        return [self._ureg.Unit(u) for u in DEFAULT_OPTIONS.get(dims, [])]
+
     def _update_units_combo_choices(self):
         if self._value.dimensionless:
             with signals_blocked(self._units_combo):
@@ -122,13 +128,7 @@ class QQuantity(QWidget):
             return
 
         units = self._value.units
-        dims, exp = next(iter(units.dimensionality.items()))
-        if exp != 1:
-            raise NotImplementedError("Inverse units not yet implemented")
-        options = [
-            self._format_units(self._ureg.Unit(u))
-            for u in DEFAULT_OPTIONS.get(dims, [])
-        ]
+        options = [self._format_units(u) for u in self._get_unit_options(units)]
         current = self._format_units(units)
         with signals_blocked(self._units_combo):
             self._units_combo.clear()

--- a/src/superqt/spinbox/_quantity.py
+++ b/src/superqt/spinbox/_quantity.py
@@ -113,7 +113,8 @@ class QQuantity(QWidget):
     def _get_unit_options(self, units: Unit) -> list[Unit]:
         if len(units.dimensionality) > 1:
             raise NotImplementedError(
-                "QQuantity does not currently support quantities with derived units."
+                "QQuantity does not currently support quantities with non-simple units,"
+                " e.g. `meter/second` or `Newton`."
             )
         dims, exp = next(iter(units.dimensionality.items()))
 

--- a/src/superqt/spinbox/_quantity.py
+++ b/src/superqt/spinbox/_quantity.py
@@ -231,4 +231,4 @@ class QQuantity(QWidget):
     def _format_units(self, u: Unit | str) -> str:
         if isinstance(u, str):
             return u
-        return f"{u:~}" if self._abbreviate_units else f"{u:}"
+        return f"{u:~P}" if self._abbreviate_units else f"{u:}"

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -1,3 +1,4 @@
+import pytest
 from pint import Quantity
 
 from superqt import QQuantity
@@ -31,6 +32,29 @@ def test_qquantity(qtbot):
     assert w.isDimensionless()
     assert w.unitsComboBox().currentText() == "-----"
     assert w.magnitude() == 1
+
+
+def test_qquantity_exponents(qtbot):
+    w = QQuantity(1, "m^2")
+    qtbot.addWidget(w)
+
+    assert w.value() == 1 * w.unitRegistry().meter ** 2
+    assert w.magnitude() == 1
+    assert w.units() == w.unitRegistry().meter ** 2
+    assert w.text() == "1 meter ** 2"
+    w.setUnits("cm^2")
+    assert w.value() == 10000 * w.unitRegistry().centimeter ** 2
+    assert w.magnitude() == 10000
+    assert w.units() == w.unitRegistry().centimeter ** 2
+    assert w.text() == "10000.0 centimeter ** 2"
+
+
+def test_qquantity_non_simple_units(qtbot):
+    with pytest.raises(NotImplementedError):
+        qtbot.addWidget(QQuantity(1, "m/s"))
+
+    with pytest.raises(NotImplementedError):
+        qtbot.addWidget(QQuantity(1, "N"))
 
 
 def test_change_qquantity_value(qtbot):


### PR DESCRIPTION
Fixes #339.

**Added:**
- Units with exponents (`1/s`, `m^2`) are supported
- Raises a `NotImplementedError` when using non-simple units (`m/s`, `N`).

There is probably a world where it wouldn't be too hard to infer the prefixes if it's a single unit like `N`, but I'm not tackling that right now. 

I have also updated the docs and added corresponding tests.