### PR TITLE
chore: Update napari test workflows

### DIFF
--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -103,7 +103,7 @@ jobs:
     secrets: inherit
 
   test_napari:
-    uses: pyapp-kit/workflows/.github/workflows/test-dependents.yml@v2
+    uses: pyapp-kit/workflows/.github/workflows/test-dependents.yml@65abcc0b091a0d45dbe3c589266160cc9b62f8dc
     with:
       dependency-repo: napari/napari
       dependency-group: "testing"

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -106,10 +106,10 @@ jobs:
     uses: pyapp-kit/workflows/.github/workflows/test-dependents.yml@v2
     with:
       dependency-repo: napari/napari
-      dependency-extras: "testing"
+      dependency-group: "testing"
       qt: ${{ matrix.qt }}
       pytest-args: 'src/napari/_qt --import-mode=importlib -k "not async and not qt_dims_2 and not qt_viewer_console_focus and not keybinding_editor and not preferences_dialog_not_dismissed"'
-      python-version: "3.10"
+      python-version: "3.13"
       post-install-cmd: "pip install lxml_html_clean"
     strategy:
       fail-fast: false

--- a/.github/workflows/test_and_deploy.yml
+++ b/.github/workflows/test_and_deploy.yml
@@ -103,7 +103,7 @@ jobs:
     secrets: inherit
 
   test_napari:
-    uses: pyapp-kit/workflows/.github/workflows/test-dependents.yml@65abcc0b091a0d45dbe3c589266160cc9b62f8dc
+    uses: pyapp-kit/workflows/.github/workflows/test-dependents.yml@main
     with:
       dependency-repo: napari/napari
       dependency-group: "testing"


### PR DESCRIPTION
napari/napari#8704

1. bump python version to 3.13 for more recent (we will drop py 3.10 in the near future)
2. uses `dependency-group` from workflow setup