### PR TITLE
Fix extra border around range slider bar

### DIFF
--- a/src/superqt/sliders/_range_style.py
+++ b/src/superqt/sliders/_range_style.py
@@ -79,7 +79,9 @@ class RangeSliderStyle:
             QPalette.ColorGroup.Disabled: "pen_disabled",  # 1
             QPalette.ColorGroup.Inactive: "pen_inactive",  # 2
         }[cg]
-        val = getattr(self, attr) or getattr(SYSTEM_STYLE, attr)
+        val = getattr(self, attr)
+        if not val and not self.has_stylesheet:
+            val = getattr(SYSTEM_STYLE, attr)
         if not val:
             return Qt.PenStyle.NoPen
         if isinstance(val, str):


### PR DESCRIPTION
- fix part 2 of #338
- fix #292

Extracted from #345 since part of that PR is not working, but this works on its own.

This only fixes the extra "border" around the range bar in the middle of the slider.

Before:

<img width="202" height="160" alt="image" src="https://github.com/user-attachments/assets/6a4ab2d2-58c9-46c8-90ac-c32c6117856b" />


After:

<img width="202" height="160" alt="image" src="https://github.com/user-attachments/assets/bceb0164-e7ec-4f6f-b687-ea60e4d37c53" />


```py
from superqt import QRangeSlider, QLabeledDoubleRangeSlider, QDoubleRangeSlider, QLabeledRangeSlider
from qtpy.QtWidgets import QWidget, QVBoxLayout, QSlider
from qtpy.QtCore import Qt

w = QWidget()
l = QVBoxLayout()
w.setLayout(l)
QSS = """
QSlider::groove:horizontal {
    background-color: cyan;
    height: 10px;
}
QSlider::handle:horizontal {
    background-color: magenta;
    width: 10px;
}
QRangeSlider {
    qproperty-barColor: green;
}
"""

for cls in (QRangeSlider, QLabeledRangeSlider, QDoubleRangeSlider, QLabeledDoubleRangeSlider):
    slider = cls(Qt.Orientation.Horizontal)
    slider.setStyleSheet(QSS)
    value = (20, 80)
    slider.setValue(value)
    l.addWidget(slider)
w.show()
```