### PR TITLE
QQuantity specify compound unit options

### DIFF
--- a/src/superqt/spinbox/_quantity.py
+++ b/src/superqt/spinbox/_quantity.py
@@ -2,6 +2,8 @@ from typing import TYPE_CHECKING, TypeAlias, Union
 
 try:
     from pint import Quantity, Unit, UnitRegistry
+    from pint._typing import UnitLike
+    from pint.facets.plain.unit import PlainUnit
     from pint.util import UnitsContainer
 except ImportError as e:
     raise ImportError(
@@ -102,15 +104,16 @@ class QQuantity(QWidget):
         self._update_units_combo_choices()
 
         self.setLayout(QHBoxLayout())
-        self.layout().addWidget(self._mag_spinbox)
-        self.layout().addWidget(self._units_combo)
-        self.layout().setContentsMargins(6, 0, 0, 0)
+        if layout := self.layout():
+            layout.addWidget(self._mag_spinbox)
+            layout.addWidget(self._units_combo)
+            layout.setContentsMargins(6, 0, 0, 0)
 
     def unitRegistry(self) -> UnitRegistry:
         """Return the pint UnitRegistry used by this widget."""
         return self._ureg
 
-    def _get_unit_options(self, units: Unit) -> list[Unit]:
+    def _get_unit_options(self, units: Unit | PlainUnit) -> list[Unit]:
         if len(units.dimensionality) > 1:
             raise NotImplementedError(
                 "QQuantity does not currently support quantities with compound units,"
@@ -158,7 +161,7 @@ class QQuantity(QWidget):
 
     def units(self) -> Unit:
         """Return the current units."""
-        return self._value.units
+        return self._ureg.Unit(self._value.units)
 
     def dimensionality(self) -> UnitsContainer:
         """Return the current dimensionality (cast to `str` for nice repr)."""
@@ -173,15 +176,20 @@ class QQuantity(QWidget):
     def setValue(
         self,
         value: str | Quantity | Number,
-        units: UnitsContainer | str | Quantity | None = None,
+        units: UnitLike | str | Quantity | None = None,
     ) -> None:
         """Set the current value (will cast to a pint Quantity)."""
         if isinstance(value, Quantity):
             if units is not None:
                 raise ValueError("Cannot specify units if value is a Quantity")
             new_val = self._ureg.Quantity(value.magnitude, units=value.units)
+        elif units is None:
+            new_val = self._ureg.Quantity(value, units=self._value.units)
+        elif isinstance(units, Quantity):
+            new_val = self._ureg.Quantity(value, units=units.units)
         else:
-            new_val = self._ureg.Quantity(value, units=units)
+            unit_spec = units.units if isinstance(units, Quantity) else units
+            new_val = self._ureg.Quantity(value, units=unit_spec)
 
         mag_change = new_val.magnitude != self._value.magnitude
         units_change = new_val.units != self._value.units
@@ -235,7 +243,7 @@ class QQuantity(QWidget):
         """Return the `QCombBox` widget used to edit the units."""
         return self._units_combo
 
-    def _format_units(self, u: Unit | str) -> str:
+    def _format_units(self, u: Unit | PlainUnit | str) -> str:
         if isinstance(u, str):
             return u
         return f"{u:~P}" if self._abbreviate_units else f"{u:}"

--- a/src/superqt/spinbox/_quantity.py
+++ b/src/superqt/spinbox/_quantity.py
@@ -3,8 +3,7 @@ from typing import TYPE_CHECKING, TypeAlias, Union
 
 try:
     from pint import Quantity, Unit, UnitRegistry
-    from pint._typing import UnitLike
-    from pint.facets.plain.unit import PlainUnit
+    from pint.facets.plain import PlainQuantity
     from pint.util import UnitsContainer
 except ImportError as e:
     raise ImportError(
@@ -19,7 +18,10 @@ from superqt.utils import signals_blocked
 if TYPE_CHECKING:
     from decimal import Decimal
 
+    from pint.facets.plain import PlainUnit
 
+UnitLike: TypeAlias = Union[str, UnitsContainer, Unit, "PlainUnit"]
+QuantityLike: TypeAlias = Quantity | PlainQuantity
 Number: TypeAlias = Union[int, float, "Decimal"]
 UREG = UnitRegistry()
 NULL_OPTION = "-----"
@@ -76,8 +78,8 @@ class QQuantity(QWidget):
 
     def __init__(
         self,
-        value: str | Quantity | Number = 0,
-        units: UnitsContainer | str | Quantity | None = None,
+        value: str | QuantityLike | Number = 0,
+        units: UnitsContainer | UnitLike | str | PlainQuantity | None = None,
         ureg: UnitRegistry | None = None,
         units_options: Sequence[UnitLike] | None = None,
         parent: QWidget | None = None,
@@ -92,7 +94,9 @@ class QQuantity(QWidget):
                 )
 
         self._ureg = ureg
-        self._value: Quantity = self._ureg.Quantity(value, units=units)
+        if isinstance(units, (Quantity, PlainQuantity)):
+            units = units.units
+        self._value: PlainQuantity = self._ureg.Quantity(value, units=units)
         if units_options is not None:
             self._units_options = [self._ureg.Unit(u) for u in units_options]
             # check that all options are compatible with the value's dimensionality
@@ -134,7 +138,7 @@ class QQuantity(QWidget):
         """Return the pint UnitRegistry used by this widget."""
         return self._ureg
 
-    def _get_unit_options(self, units: Unit | PlainUnit) -> list[Unit]:
+    def _get_unit_options(self, units: Union[Unit, "PlainUnit"]) -> list[Unit]:
         if len(units.dimensionality) > 1:
             raise NotImplementedError(
                 "To use compound units with QQuantity (e.g., `meter/second` or `Newton`"
@@ -170,7 +174,7 @@ class QQuantity(QWidget):
 
         self._units_combo.setCurrentText(current)
 
-    def value(self) -> Quantity:
+    def value(self) -> PlainQuantity:
         """Return the current value as a `pint.Quantity`."""
         return self._value
 
@@ -197,8 +201,8 @@ class QQuantity(QWidget):
 
     def setValue(
         self,
-        value: str | Quantity | Number,
-        units: UnitLike | str | Quantity | None = None,
+        value: str | QuantityLike | Number,
+        units: UnitLike | str | PlainQuantity | None = None,
     ) -> None:
         """Set the current value (will cast to a pint Quantity)."""
         if isinstance(value, Quantity):
@@ -207,11 +211,10 @@ class QQuantity(QWidget):
             new_val = self._ureg.Quantity(value.magnitude, units=value.units)
         elif units is None:
             new_val = self._ureg.Quantity(value, units=self._value.units)
-        elif isinstance(units, Quantity):
+        elif isinstance(units, (Quantity, PlainQuantity)):
             new_val = self._ureg.Quantity(value, units=units.units)
         else:
-            unit_spec = units.units if isinstance(units, Quantity) else units
-            new_val = self._ureg.Quantity(value, units=unit_spec)
+            new_val = self._ureg.Quantity(value, units=units)
 
         mag_change = new_val.magnitude != self._value.magnitude
         units_change = new_val.units != self._value.units
@@ -239,7 +242,7 @@ class QQuantity(QWidget):
         """Set the magnitude of the current value."""
         self.setValue(self._ureg.Quantity(magnitude, self._value.units))
 
-    def setUnits(self, units: str | Unit | Quantity | None) -> None:
+    def setUnits(self, units: str | UnitLike | PlainQuantity | None) -> None:
         """Set the units of the current value.
 
         If `units` is `None`, will convert to a dimensionless quantity.
@@ -248,6 +251,8 @@ class QQuantity(QWidget):
         if units is None:
             new_val = self._ureg.Quantity(self._value.magnitude)
         elif self.isDimensionless():
+            if isinstance(units, (Quantity, PlainQuantity)):
+                units = units.units
             new_val = self._ureg.Quantity(self._value.magnitude, units)
         else:
             new_val = self._value.to(units)
@@ -265,7 +270,7 @@ class QQuantity(QWidget):
         """Return the `QCombBox` widget used to edit the units."""
         return self._units_combo
 
-    def _format_units(self, u: Unit | PlainUnit | str) -> str:
+    def _format_units(self, u: UnitLike) -> str:
         if isinstance(u, str):
             return u
         return f"{u:~P}" if self._abbreviate_units else f"{u:}"

--- a/src/superqt/spinbox/_quantity.py
+++ b/src/superqt/spinbox/_quantity.py
@@ -1,3 +1,4 @@
+from collections.abc import Sequence
 from typing import TYPE_CHECKING, TypeAlias, Union
 
 try:
@@ -61,6 +62,10 @@ class QQuantity(QWidget):
         The unit registry to use.  If not provided, the registry will be extracted
         from `value` if it is a `pint.Quantity`, otherwise the default registry will
         be used.
+    units_options : Sequence[str | pint.Unit | pint.UnitsContainer], optional
+        A list of units to show in the units combo box.  If not provided, a default list
+        of units will be shown based on the dimensionality of `value`. Only necessary
+        for compound units.
     parent : QWidget, optional
         The parent widget, by default None
     """
@@ -74,6 +79,7 @@ class QQuantity(QWidget):
         value: str | Quantity | Number = 0,
         units: UnitsContainer | str | Quantity | None = None,
         ureg: UnitRegistry | None = None,
+        units_options: Sequence[UnitLike] | None = None,
         parent: QWidget | None = None,
     ) -> None:
         super().__init__(parent=parent)
@@ -87,6 +93,21 @@ class QQuantity(QWidget):
 
         self._ureg = ureg
         self._value: Quantity = self._ureg.Quantity(value, units=units)
+        if units_options is not None:
+            self._units_options = [self._ureg.Unit(u) for u in units_options]
+            # check that all options are compatible with the value's dimensionality
+            invalid_units = [
+                u
+                for u in self._units_options
+                if u.dimensionality != self._value.dimensionality
+            ]
+            if invalid_units:
+                raise ValueError(
+                    f"Units {invalid_units} are not compatible with value"
+                    f" dimensionality {self._value.dimensionality}."
+                )
+        else:
+            self._units_options = None
 
         # whether to preserve quantity equality when changing units or magnitude
         self._preserve_quantity: bool = False
@@ -116,15 +137,13 @@ class QQuantity(QWidget):
     def _get_unit_options(self, units: Unit | PlainUnit) -> list[Unit]:
         if len(units.dimensionality) > 1:
             raise NotImplementedError(
-                "QQuantity does not currently support quantities with compound units,"
-                " e.g. `meter/second` or `Newton`."
+                "To use compound units with QQuantity (e.g., `meter/second` or `Newton`"
+                "), please specify the `units_options` argument."
             )
         dims, exp = next(iter(units.dimensionality.items()))
 
         options = DEFAULT_OPTIONS.get(dims, [])
-        if exp != 1:
-            options = [f"({u})^{exp}" for u in options]
-        return [Unit(u) for u in options]
+        return [Unit(u) * exp for u in options]
 
     def _update_units_combo_choices(self):
         if self._value.dimensionless:
@@ -138,7 +157,10 @@ class QQuantity(QWidget):
             return
 
         units = self._value.units
-        options = [self._format_units(u) for u in self._get_unit_options(units)]
+        options = [
+            self._format_units(u)
+            for u in self._units_options or self._get_unit_options(units)
+        ]
         current = self._format_units(units)
         with signals_blocked(self._units_combo):
             self._units_combo.clear()

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -49,12 +49,28 @@ def test_qquantity_exponents(qtbot):
     assert w.text() == "10000.0 centimeter ** 2"
 
 
-def test_qquantity_non_simple_units(qtbot):
+def test_qquantity_compound_units(qtbot):
     with pytest.raises(NotImplementedError):
         qtbot.addWidget(QQuantity(1, "m/s"))
 
     with pytest.raises(NotImplementedError):
         qtbot.addWidget(QQuantity(1, "N"))
+
+    # Manually specify units
+    w = QQuantity(1, "m/s", units_options=["m/s", "km/h", "miles/h"])
+    qtbot.addWidget(w)
+    assert w.value() == 1 * w.unitRegistry().meter / w.unitRegistry().second
+    assert w.magnitude() == 1
+    assert w.units() == w.unitRegistry().meter / w.unitRegistry().second
+    assert w.text() == "1 meter / second"
+    w.setUnits("km/h")
+    assert w.value() == 3.6 * w.unitRegistry().kilometer / w.unitRegistry().hour
+    assert w.magnitude() == 3.6
+    assert w.units() == w.unitRegistry().kilometer / w.unitRegistry().hour
+
+    # Incompatible units
+    with pytest.raises(ValueError):
+        qtbot.addWidget(QQuantity(1, "m/s", units_options=["kg", "s"]))
 
 
 def test_change_qquantity_value(qtbot):

--- a/tests/test_quantity.py
+++ b/tests/test_quantity.py
@@ -64,7 +64,7 @@ def test_qquantity_compound_units(qtbot):
     assert w.units() == w.unitRegistry().meter / w.unitRegistry().second
     assert w.text() == "1 meter / second"
     w.setUnits("km/h")
-    assert w.value() == 3.6 * w.unitRegistry().kilometer / w.unitRegistry().hour
+    assert w.value() == w.unitRegistry().Quantity(3.6, "km/h")
     assert w.magnitude() == 3.6
     assert w.units() == w.unitRegistry().kilometer / w.unitRegistry().hour
 


### PR DESCRIPTION
It was bugging me that the `QQuantity` was useless for anyone using a compound unit when it seemed like such a simple feature to allow the user to specify the units they want to use. So here we are.

A few things I'd like some thoughts on:

- I went with the term `units_options` to be consistent with the naming of other internal variables, like the `units` parameter and `QQuantity._units_combo`, but I think that `unit_options` makes more grammatical sense.

- I redid some of the type annotations to use `pint.facets.plain.PlainQuantity` and `pint.facets.plain.PlainUnit` because my Pylance was putting red squiggles on a lot of things. For instance, creating a unit out of the `ureg` directly seems to give a `PlainQuantity` rather than a `pint.Quantity` (which inherits from `PlainQuantity`). I probably could've implemented this with better intentionality, but the squiggles are gone. I don't mind reverting some of this if you want.

- `QQuantity.setValue()` allows for changing the dimensionality of the quantity. If so, should it also accept a `units_options` (or `unit_options`) parameter?

- The docs probably need to be updated again.