### PR TITLE
Fix large integer ranges on QRangeSlider / QLabeledRangeSlider

### DIFF
--- a/src/superqt/sliders/_generic_slider.py
+++ b/src/superqt/sliders/_generic_slider.py
@@ -168,7 +168,11 @@ class _GenericSlider(QSlider):
 
         if oldMin != self._minimum or oldMax != self._maximum:
             self.sliderChange(self.SliderChange.SliderRangeChange)
-            self.rangeChanged.emit(self._minimum, self._maximum)
+            # Cast to float: rangeChanged is rebound to frangeChanged
+            # (Signal(float, float)). On Windows + older PySide6, emitting a
+            # Python int larger than C long (e.g. 10**11) raises OverflowError
+            # even though the signal is typed as double. See #308.
+            self.rangeChanged.emit(float(self._minimum), float(self._maximum))
             self.setValue(self._value)  # re-bound
 
     def tickInterval(self) -> float:  # type: ignore

--- a/src/superqt/sliders/_labeled.py
+++ b/src/superqt/sliders/_labeled.py
@@ -351,6 +351,7 @@ class QLabeledDoubleSlider(QLabeledSlider):
 class QLabeledRangeSlider(_SliderProxy, QAbstractSlider):
     valuesChanged = Signal(tuple)
     editingFinished = Signal()
+    frangeChanged = Signal(float, float)
 
     _slider_class = QRangeSlider
     _slider: QRangeSlider
@@ -515,6 +516,7 @@ class QLabeledRangeSlider(_SliderProxy, QAbstractSlider):
     # ------------- private methods ----------------
     def _rename_signals(self) -> None:
         self.valueChanged = self.valuesChanged
+        self.rangeChanged = self.frangeChanged
 
     def _reposition_labels(self) -> None:
         if (

--- a/src/superqt/sliders/_labeled.py
+++ b/src/superqt/sliders/_labeled.py
@@ -300,9 +300,7 @@ class QLabeledSlider(_SliderProxy, QAbstractSlider):
             self._label.setSuffix(f" / {max_}")
         else:
             self._label.setSuffix("")
-        # float() so large integer ranges work when rangeChanged is rebound to
-        # frangeChanged (QLabeledDoubleSlider / #308 on Windows + PySide6).
-        self.rangeChanged.emit(float(min_), float(max_))
+        self.rangeChanged.emit(min_, max_)
 
     def _on_slider_value_changed(self, v: Any) -> None:
         self._label.setValue(v)

--- a/src/superqt/sliders/_labeled.py
+++ b/src/superqt/sliders/_labeled.py
@@ -300,7 +300,9 @@ class QLabeledSlider(_SliderProxy, QAbstractSlider):
             self._label.setSuffix(f" / {max_}")
         else:
             self._label.setSuffix("")
-        self.rangeChanged.emit(min_, max_)
+        # float() so large integer ranges work when rangeChanged is rebound to
+        # frangeChanged (QLabeledDoubleSlider / #308 on Windows + PySide6).
+        self.rangeChanged.emit(float(min_), float(max_))
 
     def _on_slider_value_changed(self, v: Any) -> None:
         self._label.setValue(v)

--- a/src/superqt/sliders/_sliders.py
+++ b/src/superqt/sliders/_sliders.py
@@ -33,7 +33,13 @@ class QIntSlider(_IntMixin, _GenericSlider):
 
 
 class QRangeSlider(_IntMixin, _GenericRangeSlider):
-    pass
+    def _rename_signals(self) -> None:
+        super()._rename_signals()
+        # QSlider.rangeChanged is Signal(int, int) and cannot carry values
+        # outside the signed 32-bit range. Rebind to frangeChanged so large
+        # integer ranges (e.g. 0..10**11 in examples/labeled_sliders.py) work.
+        # Mirrors QDoubleRangeSlider. See #308.
+        self.rangeChanged = self.frangeChanged
 
 
 class QDoubleRangeSlider(_FloatMixin, QRangeSlider):

--- a/tests/zz_test_sliders/test_labeled_slider.py
+++ b/tests/zz_test_sliders/test_labeled_slider.py
@@ -132,3 +132,19 @@ def test_slider_label_decimals_update_text(qtbot):
 
     slider.setDecimals(4)
     assert slider._label.text() == "3.1416"
+
+
+def test_qlabeled_range_slider_large_range_does_not_typeerror(qtbot):
+    """Regression for examples/labeled_sliders.py on Windows/PyQt6 (#308)."""
+    sld = QLabeledRangeSlider()
+    qtbot.addWidget(sld)
+    big = 10**11
+    # setRange should not raise TypeError from rangeChanged.emit
+    sld.setRange(0, big)
+    assert sld.minimum() == 0
+    assert sld.maximum() == big
+    # example also sets a large value tuple
+    sld.setValue((20, 60 * 10**9))
+    v = sld.value()
+    assert v[0] == 20
+    assert v[1] == 60 * 10**9

--- a/tests/zz_test_sliders/test_range_slider.py
+++ b/tests/zz_test_sliders/test_range_slider.py
@@ -236,24 +236,27 @@ def test_rangeslider_signals(cls, orientation, qtbot):
     _assert_types(mock.call_args.args, tuple)
     _assert_types(mock.call_args.args[0], type_)
 
+    # rangeChanged is rebound to frangeChanged (float, float) so values outside
+    # the signed 32-bit range work (see #308). Signal args are therefore float
+    # for all range slider variants, including the integer ones.
     mock = Mock()
     sld.rangeChanged.connect(mock)
     with qtbot.waitSignal(sld.rangeChanged):
         sld.setMinimum(3)
     mock.assert_called_once_with(3, 99)
-    _assert_types(mock.call_args.args, type_)
+    _assert_types(mock.call_args.args, float)
 
     mock.reset_mock()
     with qtbot.waitSignal(sld.rangeChanged):
         sld.setMaximum(15)
     mock.assert_called_once_with(3, 15)
-    _assert_types(mock.call_args.args, type_)
+    _assert_types(mock.call_args.args, float)
 
     mock.reset_mock()
     with qtbot.waitSignal(sld.rangeChanged):
         sld.setRange(1, 2)
     mock.assert_called_once_with(1, 2)
-    _assert_types(mock.call_args.args, type_)
+    _assert_types(mock.call_args.args, float)
 
 
 @pytest.mark.parametrize("cls, orientation", ALL_SLIDER_COMBOS)
@@ -290,3 +293,14 @@ def test_range_slider_with_equal_min_max(cls, orientation, qtbot):
     assert sld2.minimum() == 0
     assert sld2.maximum() == 0
     assert sld2.value() == (0, 0)
+
+
+def test_qrange_slider_large_range_does_not_typeerror(qtbot):
+    """Large integer ranges must not explode on rangeChanged emit (#308)."""
+    sld = QRangeSlider()
+    qtbot.addWidget(sld)
+    big = 10**11
+    with qtbot.waitSignal(sld.rangeChanged):
+        sld.setRange(0, big)
+    assert sld.minimum() == 0
+    assert sld.maximum() == big


### PR DESCRIPTION
## Summary

`examples/labeled_sliders.py` crashes on Windows with PyQt6 when it calls `QLabeledRangeSlider.setRange(0, 10**11)`. The traceback is a `TypeError` from `rangeChanged(...).emit()`: the integer range slider still used Qt's native `rangeChanged(int, int)`, which cannot carry values outside the signed 32-bit range. The double variants already rebind `rangeChanged` to `frangeChanged` (`Signal(float, float)`); this PR applies the same pattern to `QRangeSlider` and `QLabeledRangeSlider`.

This stays a small signal rebind, not the broader slider inheritance refactor discussed in #249 / #283.

## Testing

- Added regression tests for `QRangeSlider` / `QLabeledRangeSlider` with `10**11` ranges
- Reproduced the TypeError on Windows (PyQt6 6.11) before the fix; example path and new tests pass after
- `pytest tests/zz_test_sliders`: 283 passed, 50 skipped, 1 xfailed
- Existing full suite has unrelated eliding-label failures on this Windows offscreen setup (font metrics); unrelated to this change

## Related

Fixes #308
